### PR TITLE
bugfix/pixel-size

### DIFF
--- a/xslt/Pixels.xsl
+++ b/xslt/Pixels.xsl
@@ -68,37 +68,24 @@
     <!-- /Metadata/Scaling/Items/Distance[@Id=X]/Value => /OME/Image/Pixels/@PhysicalSizeX -->
     <xsl:template match="Distance">
         <xsl:param name="dim"/>
-        <xsl:param name="unit"/>
         <xsl:attribute name="PhysicalSize{$dim}">
-            <xsl:choose>
-                <xsl:when test="(($unit = 'µm') and (Value &lt; 1E-5)) ">
-                    <xsl:value-of select="number(Value) * 1000000"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="Value"/>
-                </xsl:otherwise>
-            </xsl:choose>
+            <!-- `Value` is always in meters. Convert it to µm. -->
+            <xsl:value-of select="Value * 1000000"/>
         </xsl:attribute>
-        <xsl:if test="$unit != ''">
-            <xsl:attribute name="PhysicalSize{$dim}Unit">
-                <xsl:value-of select="$unit"/>
-            </xsl:attribute>
-        </xsl:if>
+        <xsl:attribute name="PhysicalSize{$dim}Unit">
+            <xsl:text>µm</xsl:text>
+        </xsl:attribute>
     </xsl:template>
 
     <xsl:template match="Items">
-        <xsl:variable name="default_size_unit" select="/ImageDocument/Metadata/Scaling/Items/Distance/DefaultUnitFormat"/>
         <xsl:apply-templates select="Distance[@Id='X']">
             <xsl:with-param name="dim">X</xsl:with-param>
-            <xsl:with-param name="unit" select="$default_size_unit"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="Distance[@Id='Y']">
             <xsl:with-param name="dim">Y</xsl:with-param>
-            <xsl:with-param name="unit" select="$default_size_unit"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="Distance[@Id='Z']">
             <xsl:with-param name="dim">Z</xsl:with-param>
-            <xsl:with-param name="unit" select="$default_size_unit"/>
         </xsl:apply-templates>
     </xsl:template>
 


### PR DESCRIPTION
Resolves https://github.com/AllenCellModeling/czi-to-ome-xslt/issues/12

This PR addresses two flaws in our previous code for handling pixel sizes:
1. `/Metadata/Scaling/Items/Distance/Value` is always in meters.
2. Since `Value` is always in meters and the preferred unit in OME-XML is µm, we can always just convert from meters to µm.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
