### PR TITLE
Get SizeX and SizeY from ImageFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,26 @@ This work has already been incorporated into
 from aicsimageio import AICSImage
 
 img = AICSImage("your-file.czi")
-img.save("your-converted-file.ome.tiff")
+img.ome_metadata
 ```
+
+## EXSLT
+This work utilizes the EXSLT extensions for XSLT 1.0 (for example, the `str:tokenize` function). Popular XML libraries
+such as `lxml` have built in support for EXSLT. To use these extensions, include the necessary attributes on `<xsl:stylesheet>` in the
+file you are working on:
+```
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+    xmlns:str="http://exslt.org/strings" extension-element-prefixes="str">
+    ...
+```
+You can then use an EXSLT function like so:
+```
+<xsl:value-of select="str:tokenize(/Some/Path, ',')" />
+```
+
+For more information on using EXSLT and the functions avaialbe, see the [EXSLT docs](http://exslt.org/howto.html).
 
 ## Comparison with Bioformats
 

--- a/xslt/Pixels.xsl
+++ b/xslt/Pixels.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2016-06">
+    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+    xmlns:str="http://exslt.org/strings" extension-element-prefixes="str">
 
 
     <xsl:import href="Channels.xsl"/>
@@ -95,8 +96,20 @@
 
     <xsl:template name="Sizes">
         <xsl:param name="image"/>
-        <xsl:apply-templates select="$image/SizeX"/>
-        <xsl:apply-templates select="$image/SizeY"/>
+        <!-- If there is a `ParameterCollection` containing `Binning` with a status of "SuperValid", we can use the `ImageFrame` from that `ParameterCollection`
+             to get Size X and Y for a single tile. If no `ParameterCollection/Binning/@Status` is "SuperValid", we can use any other `ParameterCollection/ImageFrame`. -->
+        <xsl:variable name="param_collection" select="/ImageDocument/Metadata/HardwareSetting/ParameterCollection[ImageFrame and Binning/@Status = 'SuperValid'] | /ImageDocument/Metadata/HardwareSetting/ParameterCollection[ImageFrame and not(/ImageDocument/Metadata/HardwareSetting/ParameterCollection[Binning/@Status = 'SuperValid'])]" />
+        <!-- To get accurate values for SizeX and SizeY, we need to get the values for a single tile. These are available on the `ImageFrame` element,
+             which will have a value of the form "x_offset,y_offset,x_pixels,y_pixels".
+             NOTE: While this is the most accurate way to extract SizeX and SizeY that we know of, it may not be entirely correct for mosaic images,
+             depending on if users expect these values to correspond to a single tile or a merged tile. We will likely need to revisit this in the future. -->
+        <xsl:variable name="image_frame_vals" select="str:tokenize($param_collection/ImageFrame, ',')" />
+        <xsl:attribute name="SizeX">
+            <xsl:value-of select="$image_frame_vals[3]"/>
+        </xsl:attribute>
+        <xsl:attribute name="SizeY">
+            <xsl:value-of select="$image_frame_vals[4]"/>
+        </xsl:attribute>
         <xsl:call-template name="SizeZ">
             <xsl:with-param name="simg" select="$image"/>
         </xsl:call-template>


### PR DESCRIPTION
I learned from our users that `/ImageDocument/Metadata/Information/Image/SizeX` and `SizeY` in CZI metadata are not accurate for multi-scene images, which many or most of our images are. Instead, `/ImageDocument/Metadata/HardwareSetting/ParameterCollection/ImageFrame` is a more reliable place to extract this information from. There are some conditions that affect exactly how we should use data from this element, which are documented in the comments. Additionally, this may not result in accurate `SizeX` and `SizeY` values for mosaic images, but there are ongoing discussions on how these values should be calculated ([for example](https://github.com/AllenCellModeling/aicspylibczi/issues/77)).

Lastly, I made use of a function from EXSLT in this work, and updated the docs with info on how these can be used.