### PR TITLE
Handle case where ImageFrame doesn't exist

### DIFF
--- a/tests/resources/RBG-8bit.czi.xml
+++ b/tests/resources/RBG-8bit.czi.xml
@@ -1,0 +1,67 @@
+<ImageDocument>
+ <Metadata>
+  <CustomAttributes />
+  <Information>
+   <Document>
+    <CreationDate>2019-12-06T16:56:03.6510238-08:00</CreationDate>
+    <UserName>Timm</UserName>
+   </Document>
+   <Image>
+    <ComponentBitCount>8</ComponentBitCount>
+    <PixelType>Bgr24</PixelType>
+    <SizeX>924</SizeX>
+    <SizeY>624</SizeY>
+    <SizeT>1</SizeT>
+    <Dimensions>
+     <T>
+      <StartTime>0001-01-01T00:00:00</StartTime>
+     </T>
+    </Dimensions>
+   </Image>
+  </Information>
+  <Scaling>
+   <Metadata />
+   <AutoScaling>
+    <Type>Measured</Type>
+    <Objective>Objective.420640-9900-000</Objective>
+    <Optovar>Aquila.Tubelens 1.0x ext.</Optovar>
+    <Reflector>Reflector.none</Reflector>
+    <CameraAdapter>YokogawaCameraAdapter.1.2x</CameraAdapter>
+    <ObjectiveName>Plan-Apochromat 10x/0.45 M27</ObjectiveName>
+    <OptovarMagnification>1</OptovarMagnification>
+    <ReflectorMagnification>1</ReflectorMagnification>
+    <CameraName>Camera 2 (Left)</CameraName>
+    <CameraAdapterMagnification>1.2</CameraAdapterMagnification>
+    <CameraPixelDistance>13,13</CameraPixelDistance>
+    <CreationDateTime>12/06/2019 23:55:02</CreationDateTime>
+   </AutoScaling>
+   <Items>
+    <Distance Id="X">
+     <Value>1.0833333333333333E-06</Value>
+     <DefaultUnitFormat>µm</DefaultUnitFormat>
+    </Distance>
+    <Distance Id="Y">
+     <Value>1.0833333333333333E-06</Value>
+     <DefaultUnitFormat>µm</DefaultUnitFormat>
+    </Distance>
+   </Items>
+  </Scaling>
+  <DisplaySetting>
+   <Channels>
+    <Channel Id="Channel:0" Name="C1">
+     <BitCountRange>8</BitCountRange>
+     <PixelType>Bgr24</PixelType>
+     <DyeName>Dye1</DyeName>
+     <ColorMode>None</ColorMode>
+    </Channel>
+   </Channels>
+   <ToneMapping>
+    <Mode>None</Mode>
+    <EnhanceClipLimit>3</EnhanceClipLimit>
+    <EnhanceRegionSizePercentage>15</EnhanceRegionSizePercentage>
+   </ToneMapping>
+   <ViewerRotations>0</ViewerRotations>
+  </DisplaySetting>
+  <Layers />
+ </Metadata>
+</ImageDocument>

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -31,6 +31,7 @@ def xslt_path():
         "s_3_t_1_c_3_z_5_with_subblocks.czi.xml",
         "s_1_t_1_c_5_z_20_with_subblocks.czi.xml",
         "subblocks.czi.xml",
+        "RBG-8bit.czi.xml",
     ],
 )
 def test_transform(xslt_path: str, czi_xml_filename: str):

--- a/xslt/Pixels.xsl
+++ b/xslt/Pixels.xsl
@@ -99,17 +99,27 @@
         <!-- If there is a `ParameterCollection` containing `Binning` with a status of "SuperValid", we can use the `ImageFrame` from that `ParameterCollection`
              to get Size X and Y for a single tile. If no `ParameterCollection/Binning/@Status` is "SuperValid", we can use any other `ParameterCollection/ImageFrame`. -->
         <xsl:variable name="param_collection" select="/ImageDocument/Metadata/HardwareSetting/ParameterCollection[ImageFrame and Binning/@Status = 'SuperValid'] | /ImageDocument/Metadata/HardwareSetting/ParameterCollection[ImageFrame and not(/ImageDocument/Metadata/HardwareSetting/ParameterCollection[Binning/@Status = 'SuperValid'])]" />
-        <!-- To get accurate values for SizeX and SizeY, we need to get the values for a single tile. These are available on the `ImageFrame` element,
-             which will have a value of the form "x_offset,y_offset,x_pixels,y_pixels".
-             NOTE: While this is the most accurate way to extract SizeX and SizeY that we know of, it may not be entirely correct for mosaic images,
-             depending on if users expect these values to correspond to a single tile or a merged tile. We will likely need to revisit this in the future. -->
-        <xsl:variable name="image_frame_vals" select="str:tokenize($param_collection/ImageFrame, ',')" />
-        <xsl:attribute name="SizeX">
-            <xsl:value-of select="$image_frame_vals[3]"/>
-        </xsl:attribute>
-        <xsl:attribute name="SizeY">
-            <xsl:value-of select="$image_frame_vals[4]"/>
-        </xsl:attribute>
+        <xsl:choose>
+            <!-- If we found a `ParameterCollection` meeting the above criteria, use it to calculate SizeX and SizeY. Otherwsie, use the
+                 default SizeX and SizeY elements. -->
+            <xsl:when test="$param_collection">
+                <!-- To get accurate values for SizeX and SizeY, we need to get the values for a single tile. These are available on the `ImageFrame` element,
+                     which will have a value of the form "x_offset,y_offset,x_pixels,y_pixels".
+                     NOTE: While this is the most accurate way to extract SizeX and SizeY that we know of, it may not be entirely correct for mosaic images,
+                     depending on if users expect these values to correspond to a single tile or a merged tile. We will likely need to revisit this in the future. -->
+                <xsl:variable name="image_frame_vals" select="str:tokenize($param_collection/ImageFrame, ',')" />
+                <xsl:attribute name="SizeX">
+                    <xsl:value-of select="$image_frame_vals[3]"/>
+                </xsl:attribute>
+                <xsl:attribute name="SizeY">
+                    <xsl:value-of select="$image_frame_vals[4]"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="$image/SizeX"/>
+                <xsl:apply-templates select="$image/SizeY"/>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:call-template name="SizeZ">
             <xsl:with-param name="simg" select="$image"/>
         </xsl:call-template>


### PR DESCRIPTION
After pulling my changes from #17 into an [aicsimageio PR](https://github.com/AllenCellModeling/aicsimageio/pull/365#pullrequestreview-833540315), I learned that it's possible for a CZI to not have the `/ImageDocument/Metadata/HardwareSetting/ParameterCollection/ImageFrame` element. This PR defaults back to the former behavior in that case, and adds a test case for it.