### PR TITLE
bugfix/parse-missing-wavelength

### DIFF
--- a/tests/resources/Confocal_test_4c.czi.xml
+++ b/tests/resources/Confocal_test_4c.czi.xml
@@ -1,0 +1,8588 @@
+<ImageDocument>
+ <Metadata>
+  <Experiment Version="1.2">
+   <RunMode>OptimizeBeforePerformEnabled,ValidateAndAdaptBeforePerformEnabled,TimeStitchLoopedBlockEnabled</RunMode>
+   <BeforeHardwareSetting>Before Exp [AF488, AF555, AF647, DAPI, DAPI, AF488, AF555, AF647] Smart</BeforeHardwareSetting>
+   <AfterHardwareSetting>After Exp [AF488, AF555, AF647, DAPI, DAPI, AF488, AF555, AF647] Smart</AfterHardwareSetting>
+   <ExperimentBlockIndex>0</ExperimentBlockIndex>
+   <IsSegmented>false</IsSegmented>
+   <IsStandardMode>true</IsStandardMode>
+   <ImageTransferMode>MemoryMappedAndFileStream</ImageTransferMode>
+   <AutoSave IsActivated="false" EnableSingleFileSave="false">
+    <StorageFolder>D:\zeiss\Pictures</StorageFolder>
+    <Name>New</Name>
+    <IsAutoSubFolder>true</IsAutoSubFolder>
+    <AlwaysAddFileIndex>true</AlwaysAddFileIndex>
+    <IsAutoSubFolderExternal>true</IsAutoSubFolderExternal>
+    <IsClosedOnCompletion>false</IsClosedOnCompletion>
+    <InitialIndex>1</InitialIndex>
+    <SingleFileSaveFormat>JPG</SingleFileSaveFormat>
+    <ConvertTo8Bit>false</ConvertTo8Bit>
+    <AddXmlMetadata>false</AddXmlMetadata>
+    <ApplyDisplayMappings>false</ApplyDisplayMappings>
+    <SaveOriginalData>true</SaveOriginalData>
+    <UseChannelNames>false</UseChannelNames>
+    <Quality>90</Quality>
+    <CompressionMethod>None</CompressionMethod>
+    <SingleFileSaveDestinationFolder>D:\zeiss\Pictures</SingleFileSaveDestinationFolder>
+    <SingleFileName>New</SingleFileName>
+    <DimensionsForSeparateFolders>-C;-T;-Z;-S</DimensionsForSeparateFolders>
+    <IndexedName Name="Image" NumberOfDigits="4" Format="%N" IsIndexPersisted="true" CurrentIndex="2"/>
+   </AutoSave>
+   <Scripting IsActivated="false">
+    <RunMacroBeforeExperiment>false</RunMacroBeforeExperiment>
+    <MacroBeforeExperiment/>
+    <ErrorActionBeforeExperiment>ErrorAction_Continue</ErrorActionBeforeExperiment>
+    <RunMacroAfterExperiment>false</RunMacroAfterExperiment>
+    <MacroAfterExperiment/>
+    <ErrorActionAfterExperiment>ErrorAction_Continue</ErrorActionAfterExperiment>
+   </Scripting>
+   <BlockExecutionOrder>1</BlockExecutionOrder>
+   <LoopDefinitions/>
+   <ExperimentBlocks>
+    <AcquisitionBlock IsActivated="true" BlockReference="638626988010298817">
+     <RunMode>ComponentUpdateEnabled,StateUpdateEnabled</RunMode>
+     <BeforeHardwareSetting>AcquisitionBlock_Before</BeforeHardwareSetting>
+     <AfterHardwareSetting/>
+     <SubDimensionSetups>
+      <MultiTrackSetup IsActivated="true">
+       <IsTIRFAngleSynchronized>true</IsTIRFAngleSynchronized>
+       <ImagingDepth>0</ImagingDepth>
+       <Track IsActivated="false" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.Acquisition.WfTrackDetectionMode/>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [AF488] Smart WF</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [AF488] Smart WF</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144257029" Name="AF488" Description="">
+          <Color>#FF00FF33</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <CameraFrameSetup Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+            <ShadingReference IsActivated="true">false</ShadingReference>
+            <ShadingReferenceSource IsActivated="true">1</ShadingReferenceSource>
+            <ExposureTime IsActivated="true">300</ExposureTime>
+            <Adjust IsActivated="true">0.6</Adjust>
+            <AutoExposure IsActivated="true">false</AutoExposure>
+           </CameraFrameSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF488</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>517</DyeMaxEmission>
+           <DyeMaxExcitation>493</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0038</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 488</Name>
+           <ShortName>AF488</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FF00FF33</Color>
+           <dye_id>McNamara-Boswell-0038</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>AlbireoLEDController</DirectDevice>
+       </Track>
+       <Track IsActivated="false" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.Acquisition.WfTrackDetectionMode/>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [AF555] Smart WF</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [AF555] Smart WF</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144257030" Name="AF555" Description="">
+          <Color>#FFFF7E00</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <CameraFrameSetup Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+            <ShadingReference IsActivated="true">false</ShadingReference>
+            <ShadingReferenceSource IsActivated="true">1</ShadingReferenceSource>
+            <ExposureTime IsActivated="true">300</ExposureTime>
+            <Adjust IsActivated="true">0.6</Adjust>
+            <AutoExposure IsActivated="true">false</AutoExposure>
+           </CameraFrameSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF555</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>568</DyeMaxEmission>
+           <DyeMaxExcitation>553</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0046</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 555</Name>
+           <ShortName>AF555</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFF7E00</Color>
+           <dye_id>McNamara-Boswell-0046</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>AlbireoLEDController</DirectDevice>
+       </Track>
+       <Track IsActivated="false" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.Acquisition.WfTrackDetectionMode/>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [AF647] Smart WF</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [AF647] Smart WF</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144257031" Name="AF647" Description="">
+          <Color>#FFFF0014</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <CameraFrameSetup Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+            <ShadingReference IsActivated="true">false</ShadingReference>
+            <ShadingReferenceSource IsActivated="true">1</ShadingReferenceSource>
+            <ExposureTime IsActivated="true">300</ExposureTime>
+            <Adjust IsActivated="true">0.6</Adjust>
+            <AutoExposure IsActivated="true">false</AutoExposure>
+           </CameraFrameSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF647</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>668</DyeMaxEmission>
+           <DyeMaxExcitation>653</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0057</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 647</Name>
+           <ShortName>AF647</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFF0014</Color>
+           <dye_id>McNamara-Boswell-0057</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>AlbireoLEDController</DirectDevice>
+       </Track>
+       <Track IsActivated="false" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.Acquisition.WfTrackDetectionMode/>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [DAPI] Smart WF</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [DAPI] Smart WF</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144262021" Name="DAPI" Description="">
+          <Color>#FF00A1FF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <CameraFrameSetup Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+            <ShadingReference IsActivated="true">false</ShadingReference>
+            <ShadingReferenceSource IsActivated="true">1</ShadingReferenceSource>
+            <ExposureTime IsActivated="true">300</ExposureTime>
+            <Adjust IsActivated="true">0.6</Adjust>
+            <AutoExposure IsActivated="true">false</AutoExposure>
+           </CameraFrameSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>DAPI</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>465</DyeMaxEmission>
+           <DyeMaxExcitation>353</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0434</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>DAPI</Name>
+           <ShortName>DAPI</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FF00A1FF</Color>
+           <dye_id>McNamara-Boswell-0434</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>AlbireoLEDController</DirectDevice>
+       </Track>
+       <Track IsActivated="true" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+          <IsHighIntensityModeEnabled>false</IsHighIntensityModeEnabled>
+          <TrackLaserSettings>
+           <ParameterCollection Id="MTBLKM980LaserLine405">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine488">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine561">
+            <IsEnabled>true</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine639">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+          </TrackLaserSettings>
+          <LineStepOptimization>false</LineStepOptimization>
+          <IsLambdaSubTrack>false</IsLambdaSubTrack>
+          <AiryUnits AiryUnits="1.0000000000000082" EnforceAiryUnitOne="true"/>
+          <ShortDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </ShortDetectorRange>
+          <MiddleDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </MiddleDetectorRange>
+          <LongDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </LongDetectorRange>
+         </Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [AF555] Smart LSM</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [AF555] Smart LSM</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994163148833" Name="Ch1-T5" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorShort</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144296854" Name="ChS1-T5" Description="">
+          <Color>#FFFFFFFF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>31744</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="500.31939697265625" End="542.98375772952409"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>ChS1</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name>Channel Spectral 1</Name>
+           <ShortName>ChS1</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="true" IsSelected="false" ChannelSetupId="638626994144296855" Name="AF555-T5" Description="">
+          <Color>#FFFF7E00</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>67043328</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="551.84118928717317" End="640.4155464154411"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF555</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>568</DyeMaxEmission>
+           <DyeMaxExcitation>553</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0046</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 555</Name>
+           <ShortName>AF555</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFF7E00</Color>
+           <dye_id>McNamara-Boswell-0046</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994162367277" Name="Ch2-T5" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorLong</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994163636683" Name="ChA-T5" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880SRMetaDetector</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>MTBLaserModuleLKM980</DirectDevice>
+       </Track>
+       <Track IsActivated="true" IsSelected="false">
+        <DetectionModeSetup>
+         <Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+          <IsHighIntensityModeEnabled>false</IsHighIntensityModeEnabled>
+          <TrackLaserSettings>
+           <ParameterCollection Id="MTBLKM980LaserLine405">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine488">
+            <IsEnabled>true</IsEnabled>
+            <Intensity>0.5</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine561">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine639">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+          </TrackLaserSettings>
+          <LineStepOptimization>false</LineStepOptimization>
+          <IsLambdaSubTrack>false</IsLambdaSubTrack>
+          <AiryUnits AiryUnits="1.0000000000000098" EnforceAiryUnitOne="true"/>
+          <ShortDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </ShortDetectorRange>
+          <MiddleDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </MiddleDetectorRange>
+          <LongDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </LongDetectorRange>
+         </Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [AF488] Smart LSM</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [AF488] Smart LSM</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994176236187" Name="Ch1-T6" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorShort</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="true" IsSelected="false" ChannelSetupId="638626994144301835" Name="AF488-T6" Description="">
+          <Color>#FF00FF33</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>31744</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="498.69657501021243" End="542.98375357434634"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF488</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>517</DyeMaxEmission>
+           <DyeMaxExcitation>493</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0038</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 488</Name>
+           <ShortName>AF488</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FF00FF33</Color>
+           <dye_id>McNamara-Boswell-0038</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144301836" Name="ChS2-T6" Description="">
+          <Color>#FFFFFFFF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>67043328</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="551.84119344235091" End="637.00811767578125"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>ChS2</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name>Channel Spectral 2</Name>
+           <ShortName>ChS2</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994175902653" Name="Ch2-T6" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorLong</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994176544829" Name="ChA-T6" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880SRMetaDetector</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>MTBLaserModuleLKM980</DirectDevice>
+       </Track>
+       <Track IsActivated="true" IsSelected="true">
+        <DetectionModeSetup>
+         <Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+          <IsHighIntensityModeEnabled>false</IsHighIntensityModeEnabled>
+          <TrackLaserSettings>
+           <ParameterCollection Id="MTBLKM980LaserLine405">
+            <IsEnabled>true</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine488">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine561">
+            <IsEnabled>false</IsEnabled>
+            <Intensity>0.2</Intensity>
+           </ParameterCollection>
+           <ParameterCollection Id="MTBLKM980LaserLine639">
+            <IsEnabled>true</IsEnabled>
+            <Intensity>2</Intensity>
+           </ParameterCollection>
+          </TrackLaserSettings>
+          <LineStepOptimization>false</LineStepOptimization>
+          <IsLambdaSubTrack>false</IsLambdaSubTrack>
+          <AiryUnits AiryUnits="1.0000000000000002" EnforceAiryUnitOne="true"/>
+          <ShortDetectorRange>
+           <Left>407.5</Left>
+           <Right>500.31939697265625</Right>
+          </ShortDetectorRange>
+          <MiddleDetectorRange>
+           <Left>0</Left>
+           <Right>0</Right>
+          </MiddleDetectorRange>
+          <LongDetectorRange>
+           <Left>641.5</Left>
+           <Right>757.97205091502565</Right>
+          </LongDetectorRange>
+         </Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionMode>
+        </DetectionModeSetup>
+        <BeforeHardwareSetting>Before [DAPI, AF647] Smart LSM</BeforeHardwareSetting>
+        <AfterHardwareSetting>After [DAPI, AF647] Smart LSM</AfterHardwareSetting>
+        <TrackName/>
+        <Channels>
+         <Channel IsActivated="true" IsSelected="false" ChannelSetupId="638626994144306814" Name="DAPI-T7" Description="">
+          <Color>#FF00A1FF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorShort</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="407.5" End="500.31939697265625"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>DAPI</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>465</DyeMaxEmission>
+           <DyeMaxExcitation>353</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0434</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>DAPI</Name>
+           <ShortName>DAPI</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FF00A1FF</Color>
+           <dye_id>McNamara-Boswell-0434</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144306815" Name="ChS1-T7" Description="">
+          <Color>#FFFFFFFF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>31744</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="500.31939697265625" End="542.98375772952409"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>ChS1</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name>Channel Spectral 1</Name>
+           <ShortName>ChS1</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994144306816" Name="ChS2-T7" Description="">
+          <Color>#FFFFFFFF</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorMeta</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>67043328</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="551.84119344235091" End="637.00811767578125"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>ChS2</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name>Channel Spectral 2</Name>
+           <ShortName>ChS2</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+         <Channel IsActivated="true" IsSelected="true" ChannelSetupId="638626994144306817" Name="AF647-T7" Description="">
+          <Color>#FFFF0014</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880DetectorLong</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges>
+             <EffectiveRange Start="641.5" End="757.97205091502565"/>
+            </EffectiveRanges>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <ShortName>AF647</ShortName>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <DyeMaxEmission>668</DyeMaxEmission>
+           <DyeMaxExcitation>653</DyeMaxExcitation>
+           <DyeId>McNamara-Boswell-0057</DyeId>
+           <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+          </AdditionalDyeInformation>
+          <FluorescenceDye>
+           <Name>Alexa Fluor 647</Name>
+           <ShortName>AF647</ShortName>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>ReflectedLightFluorescence</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFF0014</Color>
+           <dye_id>McNamara-Boswell-0057</dye_id>
+           <collection_id>66071726-cbd4-4c41-b371-0a6eee4ae9c5</collection_id>
+          </FluorescenceDye>
+         </Channel>
+         <Channel IsActivated="false" IsSelected="false" ChannelSetupId="638626994177251718" Name="ChA-T7" Description="">
+          <Color>#FFD3D3D3</Color>
+          <PixelShiftX>0</PixelShiftX>
+          <PixelShiftY>0</PixelShiftY>
+          <GenerateMetaData>true</GenerateMetaData>
+          <DataGrabberSetup>
+           <LsmAcquisitionSetup Id="MTBLSMImagingDevice" IsHidden="false">
+            <BitsPerPixel>8</BitsPerPixel>
+            <DetectorId>MTBLSM880SRMetaDetector</DetectorId>
+            <DetectionRangeStart>400</DetectionRangeStart>
+            <DetectionRangeEnd>700</DetectionRangeEnd>
+            <DigitalGain>1</DigitalGain>
+            <DigitalOffset>0</DigitalOffset>
+            <DetectorGrabMode>Integration</DetectorGrabMode>
+            <DetectorBinningMask>-1</DetectorBinningMask>
+            <EffectiveRanges/>
+           </LsmAcquisitionSetup>
+          </DataGrabberSetup>
+          <AdditionalDyeInformation>
+           <IlluminationType>Fluorescence</IlluminationType>
+          </AdditionalDyeInformation>
+          <ContrastMethod>
+           <Name/>
+           <ShortName/>
+           <Description/>
+           <IlluminationType>Fluorescence</IlluminationType>
+           <ContrastMethods>Unknown</ContrastMethods>
+           <ContrastTypes>Unknown</ContrastTypes>
+           <Color>#FFFFFFFF</Color>
+          </ContrastMethod>
+         </Channel>
+        </Channels>
+        <IsExtendedSetupModificationWarningShown>false</IsExtendedSetupModificationWarningShown>
+        <ZStackMode>Yes</ZStackMode>
+        <UseZStackCenter>true</UseZStackCenter>
+        <ZStackSliceIndex>1</ZStackSliceIndex>
+        <IsDisabledForApoTome>false</IsDisabledForApoTome>
+        <FocusOffset>0</FocusOffset>
+        <DirectDevice>MTBLaserModuleLKM980</DirectDevice>
+       </Track>
+       <SubDimensionSetups/>
+      </MultiTrackSetup>
+      <RegionsSetup IsActivated="false">
+       <SampleHolder>
+        <Overlap>0.1</Overlap>
+        <ScanMode>Meander</ScanMode>
+        <PositionedRegionsScanMode>FirstYThenX</PositionedRegionsScanMode>
+        <TemplateShapesScanMode>Meander</TemplateShapesScanMode>
+        <IsConstantTiles>false</IsConstantTiles>
+        <TileRegionAnchorMode>Center</TileRegionAnchorMode>
+        <StageReferencePoint>0,0</StageReferencePoint>
+        <UseStageBacklashCorrection>true</UseStageBacklashCorrection>
+        <UseFocusBacklashCorrection>true</UseFocusBacklashCorrection>
+        <IsOptimizedPositionedRegionsSorting>true</IsOptimizedPositionedRegionsSorting>
+        <IsOptimizedTemplateShapesSorting>true</IsOptimizedTemplateShapesSorting>
+        <UseStageContinualSpeed>false</UseStageContinualSpeed>
+        <StageContinualSpeed>0.8</StageContinualSpeed>
+        <UseStageContinualAcceleration>false</UseStageContinualAcceleration>
+        <StageContinualAcceleration>0.5</StageContinualAcceleration>
+        <MoveToLoadPositionBetweenRegions>false</MoveToLoadPositionBetweenRegions>
+        <MoveToLoadPositionBetweenShapes>false</MoveToLoadPositionBetweenShapes>
+        <SplitScenesInSeparateFiles>false</SplitScenesInSeparateFiles>
+        <TileRegionCoveringMode>AlignedToLocalTileRegion</TileRegionCoveringMode>
+        <TemplateShapesFillMode>FillGrade</TemplateShapesFillMode>
+        <TemplateShapesFillGrade>0.25</TemplateShapesFillGrade>
+        <TemplateShapesFillWidth>10</TemplateShapesFillWidth>
+        <TemplateShapesFillHeight>10</TemplateShapesFillHeight>
+        <IsOnlineStitchingEnabled>false</IsOnlineStitchingEnabled>
+        <IsOnlinePyramidEnabled>true</IsOnlinePyramidEnabled>
+        <GlobalInterpolationExpansionDegree>2</GlobalInterpolationExpansionDegree>
+        <LocalInterpolationExpansionDegree>2</LocalInterpolationExpansionDegree>
+        <IsFocusSurfaceOutlierRemovingEnabled>true</IsFocusSurfaceOutlierRemovingEnabled>
+        <FocusSurfaceOutlierExpansionDegree>1</FocusSurfaceOutlierExpansionDegree>
+        <FocusSurfaceOutlierThresholdSigma>2.75</FocusSurfaceOutlierThresholdSigma>
+        <UseDefaultSurfaceFit>true</UseDefaultSurfaceFit>
+        <UsedSurfaceFitTypeName/>
+        <DelayAfterStageMove>0</DelayAfterStageMove>
+        <SelectedSupportPointDistributionMode>Grid</SelectedSupportPointDistributionMode>
+        <SupportPointColumns>2</SupportPointColumns>
+        <SupportPointRows>2</SupportPointRows>
+        <OnionSkinDistributionDensity>0.05</OnionSkinDistributionDensity>
+        <OnionSkinDistributionMargin>1</OnionSkinDistributionMargin>
+        <OnionSkinDistributionMaxPoints>24</OnionSkinDistributionMaxPoints>
+        <AreSupportPointsAutomaticallyDistributedForNewTileRegions>false</AreSupportPointsAutomaticallyDistributedForNewTileRegions>
+        <TileDimension>
+         <Width>134.687302</Width>
+         <Height>134.687302</Height>
+         <CenterOffsetX>0</CenterOffsetX>
+         <CenterOffsetY>0</CenterOffsetY>
+        </TileDimension>
+        <OnlineStitchingParameter>
+         <UseFocusReferenceChannel>true</UseFocusReferenceChannel>
+         <ReferenceChannelId>0</ReferenceChannelId>
+        </OnlineStitchingParameter>
+        <AllowedScanArea IsActivated="false">
+         <ContourType>Rectangle</ContourType>
+         <Center>0,0</Center>
+         <Size>0,0</Size>
+        </AllowedScanArea>
+        <TileRegions>
+         <TileRegion Name="TR1" Id="638626992906688059">
+          <CenterPosition>6263.857,-2634.725</CenterPosition>
+          <ContourSize>241.805,206.743</ContourSize>
+          <Columns>2</Columns>
+          <Rows>2</Rows>
+          <Z>1902.455</Z>
+          <TemplateShapeId/>
+          <IsUsedForAcquisition>true</IsUsedForAcquisition>
+          <IsProtected>false</IsProtected>
+          <AreSupportPointsOutsideContourAllowed>false</AreSupportPointsOutsideContourAllowed>
+          <PreferSupportPointsZ>false</PreferSupportPointsZ>
+          <GeometryLockingMode>None</GeometryLockingMode>
+          <Contour Type="Rectangle"/>
+          <SupportPoints/>
+         </TileRegion>
+        </TileRegions>
+        <SingleTileRegions/>
+        <SingleTileRegionArrays/>
+       </SampleHolder>
+       <SubDimensionSetups/>
+      </RegionsSetup>
+      <TilesSetup IsActivated="false">
+       <SubDimensionSetups/>
+      </TilesSetup>
+      <LiveSetup IsActivated="false">
+       <SubDimensionSetups/>
+      </LiveSetup>
+      <PanoramaSetup IsActivated="false">
+       <SubDimensionSetups/>
+      </PanoramaSetup>
+      <HalfPupilSetup IsActivated="false">
+       <IsContainerAdaptionEnabled>true</IsContainerAdaptionEnabled>
+       <StartAngle>0</StartAngle>
+       <SubDimensionSetups/>
+      </HalfPupilSetup>
+      <TimeSeriesSetup IsActivated="false">
+       <IsLongAsPossible>false</IsLongAsPossible>
+       <IsBurstMode>false</IsBurstMode>
+       <Duration>
+        <Cycles>10</Cycles>
+       </Duration>
+       <IsFastAsPossible>false</IsFastAsPossible>
+       <Interval>
+        <TimeSpan>
+         <Value>0</Value>
+         <DefaultUnitFormat>s</DefaultUnitFormat>
+        </TimeSpan>
+       </Interval>
+       <BeforeHardwareSetting/>
+       <AfterHardwareSetting/>
+       <StartMode>
+        <Manual>
+         <DigitalIn>Trigger In 1</DigitalIn>
+         <DigitalOut>None</DigitalOut>
+         <TimeSpan>
+          <Value>0.001</Value>
+          <DefaultUnitFormat>ms</DefaultUnitFormat>
+         </TimeSpan>
+         <DateTime>
+          <Seconds>0</Seconds>
+          <Minutes>0</Minutes>
+          <Hours>0</Hours>
+         </DateTime>
+         <Interval>0</Interval>
+         <IntervalUnit>ms</IntervalUnit>
+         <MarkerDescription/>
+         <Cycles>1</Cycles>
+        </Manual>
+       </StartMode>
+       <StopMode>
+        <Manual>
+         <DigitalIn>Trigger In 1</DigitalIn>
+         <DigitalOut>None</DigitalOut>
+         <TimeSpan>
+          <Value>0.001</Value>
+          <DefaultUnitFormat>ms</DefaultUnitFormat>
+         </TimeSpan>
+         <DateTime>
+          <Seconds>0</Seconds>
+          <Minutes>0</Minutes>
+          <Hours>0</Hours>
+         </DateTime>
+         <Interval>0</Interval>
+         <IntervalUnit>ms</IntervalUnit>
+         <MarkerDescription/>
+         <Cycles>1</Cycles>
+        </Manual>
+       </StopMode>
+       <PauseBeginMode>
+        <Manual>
+         <DigitalIn>Trigger In 1</DigitalIn>
+         <DigitalOut>None</DigitalOut>
+         <TimeSpan>
+          <Value>0.001</Value>
+          <DefaultUnitFormat>ms</DefaultUnitFormat>
+         </TimeSpan>
+         <DateTime>
+          <Seconds>0</Seconds>
+          <Minutes>0</Minutes>
+          <Hours>0</Hours>
+         </DateTime>
+         <Interval>0</Interval>
+         <IntervalUnit>ms</IntervalUnit>
+         <MarkerDescription/>
+         <Cycles>1</Cycles>
+        </Manual>
+       </PauseBeginMode>
+       <PauseEndMode>
+        <Manual>
+         <DigitalIn>Trigger In 1</DigitalIn>
+         <DigitalOut>None</DigitalOut>
+         <TimeSpan>
+          <Value>0.001</Value>
+          <DefaultUnitFormat>ms</DefaultUnitFormat>
+         </TimeSpan>
+         <DateTime>
+          <Seconds>0</Seconds>
+          <Minutes>0</Minutes>
+          <Hours>0</Hours>
+         </DateTime>
+         <Interval>0</Interval>
+         <IntervalUnit>ms</IntervalUnit>
+         <MarkerDescription/>
+         <Cycles>1</Cycles>
+        </Manual>
+       </PauseEndMode>
+       <StartNextTimeSliceMode>
+        <Manual>
+         <DigitalIn>Trigger In 1</DigitalIn>
+         <DigitalOut>None</DigitalOut>
+         <TimeSpan>
+          <Value>0.001</Value>
+          <DefaultUnitFormat>ms</DefaultUnitFormat>
+         </TimeSpan>
+         <DateTime>
+          <Seconds>0</Seconds>
+          <Minutes>0</Minutes>
+          <Hours>0</Hours>
+         </DateTime>
+         <Interval>0</Interval>
+         <IntervalUnit>ms</IntervalUnit>
+         <MarkerDescription/>
+         <Cycles>1</Cycles>
+        </Manual>
+       </StartNextTimeSliceMode>
+       <TimeSeriesTriggerIntervalModeCollection/>
+       <TimeSeriesTriggerMarkerModeCollection/>
+       <SwitchCollection/>
+       <SetupExtensions/>
+       <SubDimensionSetups/>
+      </TimeSeriesSetup>
+      <ZStackSetup IsActivated="false">
+       <IsCenterMode>false</IsCenterMode>
+       <IsIntervalKept>true</IsIntervalKept>
+       <Offset>0</Offset>
+       <RefractiveIndexCorrection>1</RefractiveIndexCorrection>
+       <UseFocusBacklashCorrection>true</UseFocusBacklashCorrection>
+       <DelayAfterFocusMove>0</DelayAfterFocusMove>
+       <EnforceOptimalZDistance>false</EnforceOptimalZDistance>
+       <EnforceMovementAgainstGravity>true</EnforceMovementAgainstGravity>
+       <First>
+        <Distance>
+         <Value>-2E-06</Value>
+         <DefaultUnitFormat>um</DefaultUnitFormat>
+        </Distance>
+       </First>
+       <Last>
+        <Distance>
+         <Value>2E-06</Value>
+         <DefaultUnitFormat>um</DefaultUnitFormat>
+        </Distance>
+       </Last>
+       <Interval>
+        <Distance>
+         <Value>1E-06</Value>
+         <DefaultUnitFormat>um</DefaultUnitFormat>
+        </Distance>
+       </Interval>
+       <SetupExtensions>
+        <SetupExtension>
+         <LsmZStackSetup IsActivated="true">
+          <Extrapolate>false</Extrapolate>
+          <UseSplineInterpolation>false</UseSplineInterpolation>
+          <EnableTest>false</EnableTest>
+          <UseAutoBrightnessCorrection>false</UseAutoBrightnessCorrection>
+          <UseOptimizeSectioningAndStep>false</UseOptimizeSectioningAndStep>
+          <UseFastZ>false</UseFastZ>
+          <UseZPiezo>false</UseZPiezo>
+          <AttachTopoReference>true</AttachTopoReference>
+          <AttenuationFactor>0</AttenuationFactor>
+          <IsHighIntensityEnabled>false</IsHighIntensityEnabled>
+          <ZPositionCorrectionSettings/>
+         </LsmZStackSetup>
+        </SetupExtension>
+       </SetupExtensions>
+       <SubDimensionSetups/>
+      </ZStackSetup>
+      <ApoTomeAcquisitionSetup IsActivated="false">
+       <PhaseCount>0</PhaseCount>
+       <IsOnlineProcessing>false</IsOnlineProcessing>
+       <SubDimensionSetups/>
+      </ApoTomeAcquisitionSetup>
+      <CorrelativeSetup IsActivated="false">
+       <HolderDocument>
+        <Image/>
+        <Delta1To2>
+         <X>0</X>
+         <Y>0</Y>
+        </Delta1To2>
+        <Delta2To3>
+         <X>0</X>
+         <Y>0</Y>
+        </Delta2To3>
+        <HolderName/>
+        <IsReadOnly>false</IsReadOnly>
+        <Calibration>
+         <Marker1>
+          <X>NaN</X>
+          <Y>NaN</Y>
+          <Z>NaN</Z>
+         </Marker1>
+         <Marker2>
+          <X>NaN</X>
+          <Y>NaN</Y>
+          <Z>NaN</Z>
+         </Marker2>
+         <Marker3>
+          <X>NaN</X>
+          <Y>NaN</Y>
+          <Z>NaN</Z>
+         </Marker3>
+         <StageRotation>NaN</StageRotation>
+         <CorrectedMarkerDeltas>
+          <Delta1To2>
+           <X>NaN</X>
+           <Y>NaN</Y>
+          </Delta1To2>
+          <Delta2To3>
+           <X>NaN</X>
+           <Y>NaN</Y>
+          </Delta2To3>
+         </CorrectedMarkerDeltas>
+        </Calibration>
+        <IsHolderEnabled>true</IsHolderEnabled>
+        <HolderNumber/>
+        <CorrelativeSessionId>2483c994-6299-468f-8eb1-e4083af09302</CorrelativeSessionId>
+       </HolderDocument>
+       <SubDimensionSetups/>
+      </CorrelativeSetup>
+     </SubDimensionSetups>
+     <HelperSetups>
+      <InstrumentationHelperSetup IsActivated="false"/>
+      <AcquisitionModeSetup IsActivated="true">
+       <SelectedDetector>MTBLSMImagingDevice</SelectedDetector>
+       <Detectors>
+        <Detector Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+         <BinningList Status="Valid">0</BinningList>
+         <ApplyCameraProfile Status="Valid">false</ApplyCameraProfile>
+         <ApplyImageOrientation Status="Valid">true</ApplyImageOrientation>
+         <ExposureTime Status="Valid">5</ExposureTime>
+         <Frame Status="Valid">0,0,2464,2056</Frame>
+         <ImageOrientation Status="Valid">3</ImageOrientation>
+         <MultiThreadedAcquisition Status="Valid">false</MultiThreadedAcquisition>
+         <ContinuousAcquisitionSafeMode Status="Valid">true</ContinuousAcquisitionSafeMode>
+         <EnableSignalsForFastAcq Status="Valid"/>
+         <ShadingReference Status="Valid">false</ShadingReference>
+         <ShadingReferenceSource Status="Valid">1</ShadingReferenceSource>
+         <ShadingReferenceSourceVisibility Status="Valid">true</ShadingReferenceSourceVisibility>
+         <Resolution Status="Valid">0</Resolution>
+         <AnalogGainModeList Status="Valid">2</AnalogGainModeList>
+         <Trigger Status="Valid">false</Trigger>
+         <TriggerMode Status="Valid">0</TriggerMode>
+         <SnapShutter Status="Valid">false</SnapShutter>
+         <LiveShutter Status="Valid">false</LiveShutter>
+         <ShutterMode Status="Valid">0</ShutterMode>
+         <ShutterOpenDelay Status="Valid">0</ShutterOpenDelay>
+         <SoftwareBinningList Status="Valid">0</SoftwareBinningList>
+         <ResamplingParameterKey Status="Valid">1</ResamplingParameterKey>
+         <ResamplingModeParameterKey Status="Valid">0</ResamplingModeParameterKey>
+         <PixelClock Status="Valid">0</PixelClock>
+         <ImageDeliveryBufferCount Status="Valid">4</ImageDeliveryBufferCount>
+         <CameraExtraControlCommandName Status="Valid"/>
+         <Adjust Status="Valid">0.6</Adjust>
+         <AdjustFrameRate Status="Valid">true</AdjustFrameRate>
+         <AutoExposure Status="Valid">false</AutoExposure>
+         <AutoExposureFrame Status="Valid">Empty</AutoExposureFrame>
+         <Binning Status="Valid">1,1</Binning>
+         <BlackReference Status="Valid">false</BlackReference>
+         <DefaultDisplayGamma Status="Valid">1</DefaultDisplayGamma>
+         <DeliverExactFrame Status="Valid">false</DeliverExactFrame>
+         <DualCameraCalibration Status="Valid">false</DualCameraCalibration>
+         <DualCameraCalibrationId Status="Valid"/>
+         <ExposureDelay Status="Valid">0</ExposureDelay>
+         <CalculateExposureMaximum Status="Valid">10000</CalculateExposureMaximum>
+         <AutoExposureTolerance Status="Valid">0.05</AutoExposureTolerance>
+         <FrameRateTarget Status="Valid">12</FrameRateTarget>
+         <HDRBits Status="Valid">2</HDRBits>
+         <NoiseFilter Status="Valid">false</NoiseFilter>
+         <NoiseFilterThreshold Status="Valid">1.5</NoiseFilterThreshold>
+         <NoiseFilterWithIPP Status="Valid">false</NoiseFilterWithIPP>
+         <CenteredYFrame Status="Valid">false</CenteredYFrame>
+         <ReferenceImageCount Status="Valid">3</ReferenceImageCount>
+         <SnapMode Status="Valid">0</SnapMode>
+         <UnsharpMask Status="Valid">false</UnsharpMask>
+         <UnsharpMaskState Status="Valid"/>
+         <ImageCount Status="Valid">3</ImageCount>
+         <ImageOrientationWithIPP Status="Valid">true</ImageOrientationWithIPP>
+         <AcquisitionFrame Status="Valid">0,0,2464,2056</AcquisitionFrame>
+         <AbortOnMissedFrames Status="Valid">true</AbortOnMissedFrames>
+         <LiveShutterSignal Status="Valid">1</LiveShutterSignal>
+         <ShutterSignal Status="Valid">1</ShutterSignal>
+         <FrameTime Status="Valid">0</FrameTime>
+         <ReadoutTime Status="Valid">24.532</ReadoutTime>
+         <AntiGlow Status="Valid">1</AntiGlow>
+         <SnapWithSWTrigger Status="Valid">false</SnapWithSWTrigger>
+         <AxioCamHDR Status="Valid">false</AxioCamHDR>
+         <AxioCamNativeHDR Status="Valid">false</AxioCamNativeHDR>
+         <LineFlickerSuppression Status="Valid">2</LineFlickerSuppression>
+         <BlemishFiltering Status="Valid">true</BlemishFiltering>
+         <HighImageRateMode Status="Valid">true</HighImageRateMode>
+         <CameraSubsampling Status="Valid">0</CameraSubsampling>
+         <CameraBitsPerPixel Status="Valid">2</CameraBitsPerPixel>
+         <CameraLUT1 Status="Valid">0</CameraLUT1>
+         <CameraLUT2 Status="Valid">1</CameraLUT2>
+         <CameraGamma Status="Valid">1</CameraGamma>
+         <PreProcessingMemoryBuffersCount Status="Valid">0</PreProcessingMemoryBuffersCount>
+         <PreProcessingDiscBuffersCount Status="Valid">0</PreProcessingDiscBuffersCount>
+         <DiscMemoryType Status="Valid">false</DiscMemoryType>
+         <ApplyParametersCommand Status="Valid"/>
+         <ResetDecoderCache Status="Valid"/>
+         <CacheDecoder Status="Valid">false</CacheDecoder>
+         <AutoCompression Status="Valid">0</AutoCompression>
+         <ContinuousAcquisitionMode Status="Valid">0</ContinuousAcquisitionMode>
+         <SequenceCount Status="Valid">0</SequenceCount>
+         <SequenceProgress Status="Valid">true</SequenceProgress>
+         <LEDIntensity Status="Valid">9</LEDIntensity>
+         <LEDIntensityTrigger Status="Valid">9</LEDIntensityTrigger>
+         <AutomaticTriggerControl Status="Valid">true</AutomaticTriggerControl>
+         <SuppressTemperatureWarnings Status="Valid">false</SuppressTemperatureWarnings>
+         <AdaptExposureByBinningChange Status="Valid">false</AdaptExposureByBinningChange>
+        </Detector>
+        <Detector Id="MTBLSMImagingDevice">
+         <TrackNumber Status="Valid">
+          <TrackNumber>
+           <SpeedInfoData xsd="" xsi="">
+            <Tracks>
+             <SpeedInfoTrackData DetectionModeTypeName="Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionModeSetup" ForceExchangeXY="false">
+              <Channels>
+               <SpeedInfoChannelData NumberOfSubChannels="1" IsBinnedAiryscanInConfocal="false" IsPhotonCounting="false"/>
+              </Channels>
+             </SpeedInfoTrackData>
+             <SpeedInfoTrackData DetectionModeTypeName="Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionModeSetup" ForceExchangeXY="false">
+              <Channels>
+               <SpeedInfoChannelData NumberOfSubChannels="1" IsBinnedAiryscanInConfocal="false" IsPhotonCounting="false"/>
+              </Channels>
+             </SpeedInfoTrackData>
+             <SpeedInfoTrackData DetectionModeTypeName="Zeiss.Micro.LSM.Acquisition.Lsm880ChannelTrackDetectionModeSetup" ForceExchangeXY="false">
+              <Channels>
+               <SpeedInfoChannelData NumberOfSubChannels="1" IsBinnedAiryscanInConfocal="false" IsPhotonCounting="false"/>
+               <SpeedInfoChannelData NumberOfSubChannels="1" IsBinnedAiryscanInConfocal="false" IsPhotonCounting="false"/>
+              </Channels>
+             </SpeedInfoTrackData>
+            </Tracks>
+           </SpeedInfoData>
+          </TrackNumber>
+         </TrackNumber>
+         <SimulateInService Status="Valid">false</SimulateInService>
+         <RoiRotation Status="Valid">0</RoiRotation>
+         <RoiCenterOffsetX Status="Valid">0</RoiCenterOffsetX>
+         <RoiCenterOffsetY Status="Valid">0</RoiCenterOffsetY>
+         <Zoom Status="Valid">1,1</Zoom>
+         <ScanSpeed Status="Valid">6</ScanSpeed>
+         <ScanFrequencyOverride Status="Valid">-1</ScanFrequencyOverride>
+         <ScanAreaMode Status="Valid">Frame</ScanAreaMode>
+         <FrameSize Status="Valid">1908,1908</FrameSize>
+         <FrameOffset Status="Valid">0,0</FrameOffset>
+         <SpotScanPixelAggregationSize Status="Valid">1000,1</SpotScanPixelAggregationSize>
+         <Frame Status="Valid">954,954,1908,1908</Frame>
+         <ImageFrame Status="Valid">954,954,1908,1908</ImageFrame>
+         <BitsPerPixel Status="Valid">8</BitsPerPixel>
+         <AveragingNumber Status="Valid">2</AveragingNumber>
+         <AveragingMethod Status="Valid">Mean</AveragingMethod>
+         <AveragingMode Status="Valid">Line</AveragingMode>
+         <HdrNumber Status="Valid">1</HdrNumber>
+         <HdrMethod Status="Valid">Illumination</HdrMethod>
+         <HdrIntensity Status="Valid">1</HdrIntensity>
+         <IsHdrActivated Status="Valid">false</IsHdrActivated>
+         <ScanDirection Status="Valid">Unidirectional</ScanDirection>
+         <ScannerCorrectionX Status="Valid">0</ScannerCorrectionX>
+         <ScannerCorrectionY Status="Valid">0</ScannerCorrectionY>
+         <TrackMultiplexType Status="Valid">Frame</TrackMultiplexType>
+         <LineStep Status="Valid">1</LineStep>
+         <LineStepInterpolation Status="Valid">true</LineStepInterpolation>
+         <ColumnStep Status="Valid">1</ColumnStep>
+         <UsesOnlineCalibration Status="Valid">false</UsesOnlineCalibration>
+         <DisableBlanking Status="Valid">false</DisableBlanking>
+         <HdrKeepRawImageData Status="Valid">true</HdrKeepRawImageData>
+         <DoAiryScanBeamCentralizingInContinuousScan Status="Valid">false</DoAiryScanBeamCentralizingInContinuousScan>
+         <DoAiryScanBeamCentralizingInSlowTimeSeries Status="Valid">false</DoAiryScanBeamCentralizingInSlowTimeSeries>
+         <AiryScanBeamCentralizingStoreSecondaryAdjustmentValues Status="Valid">false</AiryScanBeamCentralizingStoreSecondaryAdjustmentValues>
+         <SamplingMode Status="Valid">Confocal</SamplingMode>
+         <Sampling Status="Valid">0.99992754528419</Sampling>
+         <SplineSupportPoints Status="Valid"/>
+         <ScaledImageRectangle Status="Valid">67.3436507936508,67.3436507936508,134.687301587302,134.687301587302</ScaledImageRectangle>
+         <ScaledImageRectangleSize Status="Valid">134.687301587302,134.687301587302</ScaledImageRectangleSize>
+         <IsMaxScanSpeedSet Status="Valid">false</IsMaxScanSpeedSet>
+        </Detector>
+       </Detectors>
+       <Devices/>
+       <MixedMode>
+        <DisparityWarpingActivated>false</DisparityWarpingActivated>
+        <DisparityMapFile/>
+        <DoAutoScalingSynchronization>false</DoAutoScalingSynchronization>
+        <SelectedScalingMaster>LSM</SelectedScalingMaster>
+        <UsedExternalImagePixelDistance>0,0</UsedExternalImagePixelDistance>
+        <UsedInternalImagePixelDistance>0,0</UsedInternalImagePixelDistance>
+       </MixedMode>
+      </AcquisitionModeSetup>
+      <AutoImmersionSetup IsActivated="false">
+       <ImmersionTimeInterval>0</ImmersionTimeInterval>
+       <ImmersionTravelDistance>0</ImmersionTravelDistance>
+       <IsBubbleEliminationMovementEnabled>false</IsBubbleEliminationMovementEnabled>
+       <BubbleEliminationMovementTargetX>20000</BubbleEliminationMovementTargetX>
+       <BubbleEliminationMovementTargetY>20000</BubbleEliminationMovementTargetY>
+      </AutoImmersionSetup>
+      <BleachingSetup IsActivated="false">
+       <BleachSettingsName>Not Defined</BleachSettingsName>
+       <BleachSettingsType>BleachingSetupExtensionLsm880</BleachSettingsType>
+       <BeforeHardwareSetting/>
+       <AfterHardwareSetting/>
+       <ExtensionSettings IsActivated="false">
+        <BleachingComponentId>MTBLSMImagingDevice</BleachingComponentId>
+        <RegionSpecificSettings>false</RegionSpecificSettings>
+        <LaserLineSettings/>
+        <AlternateZPosition>0</AlternateZPosition>
+        <HasRepetition>false</HasRepetition>
+        <HasStartIndex>false</HasStartIndex>
+        <IntensityThreshold>50</IntensityThreshold>
+        <Iterations>1</Iterations>
+        <SpotBleachDuration>500</SpotBleachDuration>
+        <Repetition>1</Repetition>
+        <SetAlternateScanSpeed>false</SetAlternateScanSpeed>
+        <AlternateScanSpeed>1</AlternateScanSpeed>
+        <SetAlternateZPosition>false</SetAlternateZPosition>
+        <StartIndex>0</StartIndex>
+        <StopOnIntensityDrop>false</StopOnIntensityDrop>
+        <ZoomBleach>false</ZoomBleach>
+        <ProtectDetectorDuringBleach>false</ProtectDetectorDuringBleach>
+        <InteractiveBleachingSetup IsActivated="true">
+         <Iterations>1</Iterations>
+         <TriggerBehaviour>0</TriggerBehaviour>
+         <Stencils/>
+        </InteractiveBleachingSetup>
+        <BleachTimeSeriesTimeSeriesMode>
+         <OnTrigger>
+          <DigitalIn>None</DigitalIn>
+          <DigitalOut>None</DigitalOut>
+          <TimeSpan>
+           <Value>0.001</Value>
+           <DefaultUnitFormat>ms</DefaultUnitFormat>
+          </TimeSpan>
+          <DateTime>
+           <Seconds>0</Seconds>
+           <Minutes>0</Minutes>
+           <Hours>0</Hours>
+          </DateTime>
+          <Interval>0</Interval>
+          <IntervalUnit>ms</IntervalUnit>
+          <MarkerDescription/>
+          <Cycles>1</Cycles>
+         </OnTrigger>
+        </BleachTimeSeriesTimeSeriesMode>
+       </ExtensionSettings>
+      </BleachingSetup>
+      <DynamicsSetup IsActivated="false" GraphicScale="1" Id="638626994144326781"/>
+      <ExperimentModifierRulesSetup IsActivated="false">
+       <Flags>
+        <RunMode/>
+       </Flags>
+      </ExperimentModifierRulesSetup>
+      <ExperimentRegionsSetup IsActivated="false">
+       <FitFrameSizeToRegions>false</FitFrameSizeToRegions>
+       <ImageCenterAsCoordinateReference>false</ImageCenterAsCoordinateReference>
+       <Regions/>
+      </ExperimentRegionsSetup>
+      <FocusSetup IsActivated="true">
+       <RepetitionSettingsMode>Standard</RepetitionSettingsMode>
+       <FocusStrategy IsActivated="true">
+        <StrategyMode>None</StrategyMode>
+        <ReferenceChannelId>638626994144257029</ReferenceChannelId>
+        <FixedZPosition>0</FixedZPosition>
+        <UseZPositionFromTilesSetup>true</UseZPositionFromTilesSetup>
+        <ExecutionInTileRegionMode>CenterOfRegion</ExecutionInTileRegionMode>
+        <SupportPointsMode>FixedZPosition</SupportPointsMode>
+        <FocusZStackMode>FixedZ</FocusZStackMode>
+        <WaitPositionMode>CenterOfFirstRegion</WaitPositionMode>
+        <WaitPositionX>0</WaitPositionX>
+        <WaitPositionY>0</WaitPositionY>
+        <WaitPositionZ>0</WaitPositionZ>
+        <IsUpdatePositionedRegionsToClientEnabled>true</IsUpdatePositionedRegionsToClientEnabled>
+        <PositionedRegionsUpdateMode>CumulatedPositions</PositionedRegionsUpdateMode>
+        <BreakAfterSupportPointsDetermination>false</BreakAfterSupportPointsDetermination>
+        <ErrorNotificationHints>None</ErrorNotificationHints>
+        <AdditionalSupportPointOffset>0</AdditionalSupportPointOffset>
+        <TimeSeriesIntervalInfo>
+         <IsActivated>false</IsActivated>
+         <IsMainIntervalEnabled>true</IsMainIntervalEnabled>
+         <IsSubIntervalEnabled>false</IsSubIntervalEnabled>
+         <MainInterval>1</MainInterval>
+         <SubInterval>1</SubInterval>
+        </TimeSeriesIntervalInfo>
+        <RegionsIntervalInfo>
+         <IsActivated>false</IsActivated>
+         <IsMainIntervalEnabled>true</IsMainIntervalEnabled>
+         <IsSubIntervalEnabled>false</IsSubIntervalEnabled>
+         <MainInterval>1</MainInterval>
+         <SubInterval>1</SubInterval>
+        </RegionsIntervalInfo>
+        <TilesIntervalInfo>
+         <IsActivated>false</IsActivated>
+         <IsMainIntervalEnabled>true</IsMainIntervalEnabled>
+         <IsSubIntervalEnabled>false</IsSubIntervalEnabled>
+         <MainInterval>1</MainInterval>
+         <SubInterval>1</SubInterval>
+        </TilesIntervalInfo>
+        <HardwareAutofocusOptions>
+         <IsSupportedBySoftwareAutofocus>false</IsSupportedBySoftwareAutofocus>
+        </HardwareAutofocusOptions>
+        <HardwareAutofocusSupportPointsModeOptions>
+         <IsSupportedBySoftwareAutofocus>false</IsSupportedBySoftwareAutofocus>
+        </HardwareAutofocusSupportPointsModeOptions>
+       </FocusStrategy>
+       <Autofocus Id="Autofocus">
+        <AutofocusStrategyMode Status="Valid">Software</AutofocusStrategyMode>
+        <AutofocusSignalQualityThreshold Status="Valid">50</AutofocusSignalQualityThreshold>
+       </Autofocus>
+       <HardwareAutofocus Id="MTBAutoFocus">
+        <Period>0</Period>
+        <AutofocusMountingAngle>0</AutofocusMountingAngle>
+        <AutofocusPositionOffset>0</AutofocusPositionOffset>
+        <AutofocusOperationMode>Exact</AutofocusOperationMode>
+        <AutofocusSpecimenType>Reflective</AutofocusSpecimenType>
+       </HardwareAutofocus>
+       <SoftwareAutofocus>
+        <ReflectionMode>Disabled</ReflectionMode>
+        <ReflectionModeOffset>-120</ReflectionModeOffset>
+        <AutofocusRegion>
+         <X>0</X>
+         <Y>0</Y>
+         <DX>1</DX>
+         <DY>1</DY>
+        </AutofocusRegion>
+        <BacklashStepsize>2</BacklashStepsize>
+        <DepthOfFocus>0.57</DepthOfFocus>
+        <DoBleachingCorrection>true</DoBleachingCorrection>
+        <InitialDirection>0</InitialDirection>
+        <IsAutomaticRange>true</IsAutomaticRange>
+        <LowerLimit>100</LowerLimit>
+        <PredefinedStepsize>Optimal</PredefinedStepsize>
+        <SharpnessMeasureMethod>Auto</SharpnessMeasureMethod>
+        <RelativeSearchRange>22.799999999999997</RelativeSearchRange>
+        <SearchRangeType>Relative</SearchRangeType>
+        <SearchStrategy>Exhaustive</SearchStrategy>
+        <SharpnessMeasureSet Name="Best" Aggregator="RootMeanSquare">
+         <SharpnessMeasure DecisionWeight="1" ScoreType="HaarGradient">
+          <Parameters>
+           <Parameter>1</Parameter>
+          </Parameters>
+         </SharpnessMeasure>
+         <SharpnessMeasure DecisionWeight="2" ScoreType="HaarGradient">
+          <Parameters>
+           <Parameter>2</Parameter>
+          </Parameters>
+         </SharpnessMeasure>
+         <SharpnessMeasure DecisionWeight="3" ScoreType="HaarGradient">
+          <Parameters>
+           <Parameter>3</Parameter>
+          </Parameters>
+         </SharpnessMeasure>
+        </SharpnessMeasureSet>
+        <UpperLimit>-100</UpperLimit>
+        <UseAcquisitionROI>true</UseAcquisitionROI>
+        <UseCameraParameters>false</UseCameraParameters>
+        <UseChannelInformation>true</UseChannelInformation>
+        <IsLiveAnalysisReportingEnabled>false</IsLiveAnalysisReportingEnabled>
+        <Extensions>
+         <Extension ID="urn:uuid:23da5db8-181d-49fa-83e5-df1c2d42f0b8" Name="LsmAutofocusCoarseSearchParameters">
+          <Mode>SinglePeak</Mode>
+          <EnforceMovementAgainstGravity>true</EnforceMovementAgainstGravity>
+          <ExtendedParameters/>
+         </Extension>
+         <Extension ID="urn:uuid:e291569a-8562-4dd2-8f37-d0afa3e81a20" Name="LsmAutofocusParameters">
+          <SearchMode>Fine, CoarseAuto</SearchMode>
+         </Extension>
+        </Extensions>
+       </SoftwareAutofocus>
+       <DefiniteFocus IsActivated="false">
+        <IsContinuousStabilizationEnabled>false</IsContinuousStabilizationEnabled>
+        <ContinuousStabilizationMode>Periodic</ContinuousStabilizationMode>
+        <Period>10</Period>
+        <OperationMode>Exact</OperationMode>
+        <IsPausedDuringAcquisition>true</IsPausedDuringAcquisition>
+        <SkipInitialization>false</SkipInitialization>
+        <DelayOnFirstTileInRegion>0</DelayOnFirstTileInRegion>
+       </DefiniteFocus>
+      </FocusSetup>
+      <LinkamRampSetup IsActivated="false">
+       <Rate>10</Rate>
+       <Limit>50</Limit>
+       <HoldTime>0</HoldTime>
+       <RampType>None</RampType>
+      </LinkamRampSetup>
+      <RatioSetup IsActivated="false">
+       <IsRatioImageGenerated>false</IsRatioImageGenerated>
+       <SelectedColorMode>Palette</SelectedColorMode>
+       <Color>#00FFFFFF</Color>
+       <PaletteName>rainbow</PaletteName>
+       <RatioDisplayMinimum>0</RatioDisplayMinimum>
+       <RatioDisplayMaximum>10</RatioDisplayMaximum>
+       <RatioMethod>DualWavelength</RatioMethod>
+       <SelectedReferenceIdChannel1>0</SelectedReferenceIdChannel1>
+       <SelectedReferenceIdChannel2>0</SelectedReferenceIdChannel2>
+       <RatioBackgroundCorrection>None</RatioBackgroundCorrection>
+       <BackgroundCorrectionChannel1>0</BackgroundCorrectionChannel1>
+       <BackgroundCorrectionChannel2>0</BackgroundCorrectionChannel2>
+       <BackgroundCorrectionFaktor1>1</BackgroundCorrectionFaktor1>
+       <BackgroundCorrectionFaktor2>1</BackgroundCorrectionFaktor2>
+       <AverageFrame>5</AverageFrame>
+       <Multiplicator>1</Multiplicator>
+       <IsOptionalThreshold>false</IsOptionalThreshold>
+       <OptionalThresholdChannel1>0</OptionalThresholdChannel1>
+       <OptionalThresholdChannel2>0</OptionalThresholdChannel2>
+       <ThresholdChannelOrderId1>0</ThresholdChannelOrderId1>
+       <ThresholdChannelOrderId2>0</ThresholdChannelOrderId2>
+       <IsRatioClipping>true</IsRatioClipping>
+       <RatioClipping>10</RatioClipping>
+       <IsRatioCalculationEnabled>true</IsRatioCalculationEnabled>
+       <IsRatioReferenceImageDefined>true</IsRatioReferenceImageDefined>
+       <AverageStartFrame>1</AverageStartFrame>
+       <AverageEndFrame>1</AverageEndFrame>
+      </RatioSetup>
+      <ResetDetectorSetup IsActivated="true">
+       <ResetDetectorsInTilesExperiment>true</ResetDetectorsInTilesExperiment>
+      </ResetDetectorSetup>
+      <TempSeriesSetup IsActivated="false">
+       <TemperatureStep>0</TemperatureStep>
+      </TempSeriesSetup>
+      <ElyraSetup IsActivated="false">
+       <Mode>Fast</Mode>
+      </ElyraSetup>
+      <BleachFrameSynchronizationSetup IsActivated="false"/>
+      <ExperimentRemoteProcessingSetup IsActivated="false">
+       <ProcessingSteps>
+        <ProcessingStep Id="Deconvolution">
+         <Algorithm>FastIterative</Algorithm>
+         <UseAdvancedSettings>false</UseAdvancedSettings>
+         <AdvancedSettingsFilePath/>
+        </ProcessingStep>
+       </ProcessingSteps>
+       <OutputFolder>D:\zeiss\Pictures</OutputFolder>
+       <IsAutoSubFolder>false</IsAutoSubFolder>
+       <FileName>processed.czi</FileName>
+       <IncludeOriginalFileName>true</IncludeOriginalFileName>
+       <SyncAutoSaveFolderToOutputFolder>true</SyncAutoSaveFolderToOutputFolder>
+       <ProcessedImageHandling>AutoOpenWhenFinished</ProcessedImageHandling>
+      </ExperimentRemoteProcessingSetup>
+     </HelperSetups>
+    </AcquisitionBlock>
+   </ExperimentBlocks>
+   <HardwareSettingsPool>
+    <HardwareSetting Name="Before Exp [AF488, AF555, AF647, DAPI] Smart">
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed IsActivated="true">true</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_FF">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_RL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_TL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After Exp [AF488, AF555, AF647, DAPI] Smart">
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed IsActivated="true">true</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_FF">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_RL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_TL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before Exp [AF488, AF555, AF647, DAPI, DAPI, AF488, AF555, AF647] Smart">
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed IsActivated="true">true</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_FF">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_RL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_TL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After Exp [AF488, AF555, AF647, DAPI, DAPI, AF488, AF555, AF647] Smart">
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed IsActivated="true">true</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_FF">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_RL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLEDArraySF_TL">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before [AF488] Smart WF">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%R</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens 1.0x</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">5</Position>
+      <PositionName IsActivated="true">Reflector.489090-9100-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled Status="Valid" IsActivated="true">true</IsEnabled>
+      <Intensity Status="Valid" IsActivated="true">75</Intensity>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="AlbireoLEDController">
+      <LampMode Status="Valid" IsActivated="true">LEDContinuous</LampMode>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [AF488] Smart WF">
+     <ParameterCollection Id="MTBLED3">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+      <Intensity IsActivated="true">0</Intensity>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before [AF555] Smart WF">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%R</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens 1.0x</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">5</Position>
+      <PositionName IsActivated="true">Reflector.489090-9100-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled Status="Valid" IsActivated="true">true</IsEnabled>
+      <Intensity Status="Valid" IsActivated="true">75</Intensity>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="AlbireoLEDController">
+      <LampMode Status="Valid" IsActivated="true">LEDContinuous</LampMode>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [AF555] Smart WF">
+     <ParameterCollection Id="MTBLED5">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+      <Intensity IsActivated="true">0</Intensity>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before [AF647] Smart WF">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%R</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens 1.0x</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">5</Position>
+      <PositionName IsActivated="true">Reflector.489090-9100-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled Status="Valid" IsActivated="true">true</IsEnabled>
+      <Intensity Status="Valid" IsActivated="true">75</Intensity>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="AlbireoLEDController">
+      <LampMode Status="Valid" IsActivated="true">LEDContinuous</LampMode>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [AF647] Smart WF">
+     <ParameterCollection Id="MTBLED6">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+      <Intensity IsActivated="true">0</Intensity>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before [DAPI] Smart WF">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%R</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens 1.0x</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">5</Position>
+      <PositionName IsActivated="true">Reflector.489090-9100-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled Status="Valid" IsActivated="true">true</IsEnabled>
+      <Intensity Status="Valid" IsActivated="true">75</Intensity>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBRLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="AlbireoLEDController">
+      <LampMode Status="Valid" IsActivated="true">LEDContinuous</LampMode>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [DAPI] Smart WF">
+     <ParameterCollection Id="MTBLED1">
+      <IsEnabled IsActivated="true">false</IsEnabled>
+      <Intensity IsActivated="true">0</Intensity>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="Before [AF555] Smart LSM">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Reflector.none</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorLong">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorMeta">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">500</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorShort">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SRMetaDetector">
+      <DetectorGain IsActivated="true">700</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880Sbs">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">SecondaryBeamsplitter.453001-4023-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsVis">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Beamsplitter.2412-349</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsInvis">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Beamsplitter.1520-117</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880EmissionFilterSR">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Beamsplitter.Plate</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880PinholeDiameter">
+      <Position Status="Valid" IsActivated="true" Unit="µm">57.279820667137</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLLampChanger">
+      <PositionName Status="Valid" IsActivated="true">Mirror.Left</PositionName>
+      <Position Status="Valid" IsActivated="true">1</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed Status="Valid" IsActivated="true">true</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SpectralGroup">
+      <OperationMode Status="Valid" IsActivated="true">Channel</OperationMode>
+      <Bands Status="Valid" IsActivated="true">
+       <Bands>
+        <BandState>
+         <Left>551.84118928717317</Left>
+         <Right>640.4155464154411</Right>
+         <IsFixed>false</IsFixed>
+         <DetectorId>middle</DetectorId>
+        </BandState>
+       </Bands>
+      </Bands>
+      <LaserBlocker0 Status="Valid" IsActivated="true">-1</LaserBlocker0>
+      <LaserBlocker1 Status="Valid" IsActivated="true">-1</LaserBlocker1>
+      <LambdaModeCenterWavelength Status="Valid" IsActivated="true">-1</LambdaModeCenterWavelength>
+      <LambdaModeSlitWidth Status="Valid" IsActivated="true">-1</LambdaModeSlitWidth>
+      <ReflectionEnabled Status="Valid" IsActivated="true">false</ReflectionEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [AF555] Smart LSM"/>
+    <HardwareSetting Name="Before [AF488] Smart LSM">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Reflector.none</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorLong">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorMeta">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">500</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain Status="Valid" IsActivated="true" Unit="V">750</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorShort">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SRMetaDetector">
+      <DetectorGain IsActivated="true">700</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880Sbs">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">SecondaryBeamsplitter.453001-4023-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsVis">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Beamsplitter.2412-349</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsInvis">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Beamsplitter.1520-117</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880EmissionFilterSR">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Beamsplitter.Plate</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880PinholeDiameter">
+      <Position Status="Valid" IsActivated="true" Unit="µm">49.664133772725</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLLampChanger">
+      <PositionName Status="Valid" IsActivated="true">Mirror.Left</PositionName>
+      <Position Status="Valid" IsActivated="true">1</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SpectralGroup">
+      <OperationMode Status="Valid" IsActivated="true">Channel</OperationMode>
+      <Bands Status="Valid" IsActivated="true">
+       <Bands>
+        <BandState>
+         <Left>498.69657501021243</Left>
+         <Right>542.98375357434634</Right>
+         <IsFixed>false</IsFixed>
+         <DetectorId>middle</DetectorId>
+        </BandState>
+       </Bands>
+      </Bands>
+      <LaserBlocker0 Status="Valid" IsActivated="true">-1</LaserBlocker0>
+      <LaserBlocker1 Status="Valid" IsActivated="true">-1</LaserBlocker1>
+      <LambdaModeCenterWavelength Status="Valid" IsActivated="true">-1</LambdaModeCenterWavelength>
+      <LambdaModeSlitWidth Status="Valid" IsActivated="true">-1</LambdaModeSlitWidth>
+      <ReflectionEnabled Status="Valid" IsActivated="true">false</ReflectionEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [AF488] Smart LSM"/>
+    <HardwareSetting Name="Before [DAPI, AF647] Smart LSM">
+     <ParameterCollection Id="MTBSideportChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.SideportElement_100%LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBReflectorChanger">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Reflector.none</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBOptovarChanger">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Aquila.Tubelens LSM</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorLong">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorMeta">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">500</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880DetectorShort">
+      <IsEnabled IsActivated="true">true</IsEnabled>
+      <MinMasterGain IsActivated="true" IsReadOnly="true">0</MinMasterGain>
+      <MaxMasterGain IsActivated="true" IsReadOnly="true">1250</MaxMasterGain>
+      <DetectorGain IsActivated="true">650</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SRMetaDetector">
+      <DetectorGain IsActivated="true">700</DetectorGain>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880Sbs">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">SecondaryBeamsplitter.453001-4023-000</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsVis">
+      <Position IsActivated="true">2</Position>
+      <PositionName IsActivated="true">Beamsplitter.2412-349</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880MbsInvis">
+      <Position IsActivated="true">3</Position>
+      <PositionName IsActivated="true">Beamsplitter.1520-117</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880EmissionFilterSR">
+      <Position IsActivated="true">1</Position>
+      <PositionName IsActivated="true">Beamsplitter.Plate</PositionName>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880PinholeDiameter">
+      <Position IsActivated="true">43.282053750585177</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLLampChanger">
+      <PositionName Status="Valid" IsActivated="true">Mirror.Left</PositionName>
+      <Position Status="Valid" IsActivated="true">1</Position>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBTLShutter">
+      <IsClosed Status="Valid" IsActivated="true">false</IsClosed>
+     </ParameterCollection>
+     <ParameterCollection Id="MTBLSM880SpectralGroup">
+      <OperationMode Status="Valid" IsActivated="true">Channel</OperationMode>
+      <Bands Status="Valid" IsActivated="true">
+       <Bands>
+        <BandState>
+         <Left>407.5</Left>
+         <Right>500.31939697265625</Right>
+         <IsFixed>false</IsFixed>
+         <DetectorId>short</DetectorId>
+        </BandState>
+        <BandState>
+         <Left>641.5</Left>
+         <Right>757.97205091502565</Right>
+         <IsFixed>false</IsFixed>
+         <DetectorId>long</DetectorId>
+        </BandState>
+       </Bands>
+      </Bands>
+      <LaserBlocker0 Status="Valid" IsActivated="true">-1</LaserBlocker0>
+      <LaserBlocker1 Status="Valid" IsActivated="true">-1</LaserBlocker1>
+      <LambdaModeCenterWavelength Status="Valid" IsActivated="true">-1</LambdaModeCenterWavelength>
+      <LambdaModeSlitWidth Status="Valid" IsActivated="true">-1</LambdaModeSlitWidth>
+      <ReflectionEnabled Status="Valid" IsActivated="true">false</ReflectionEnabled>
+     </ParameterCollection>
+    </HardwareSetting>
+    <HardwareSetting Name="After [DAPI, AF647] Smart LSM"/>
+    <HardwareSetting Name="AcquisitionBlock_Before"/>
+   </HardwareSettingsPool>
+   <ExperimentFeedback IsActivated="false">
+    <IsSynchronous>true</IsSynchronous>
+    <IsSynchronousToAnalysis>true</IsSynchronousToAnalysis>
+    <IsSynchronousToFile>false</IsSynchronousToFile>
+    <AllowNonExperimentObservablesToTriggerScript>false</AllowNonExperimentObservablesToTriggerScript>
+    <DeadlockTimeout>10</DeadlockTimeout>
+    <PreScript/>
+    <LoopScript/>
+    <PostScript/>
+    <IsWarningPopupShown>true</IsWarningPopupShown>
+    <AreDebugMessagesEnabled>false</AreDebugMessagesEnabled>
+    <Actions/>
+   </ExperimentFeedback>
+   <AdditionalSettings/>
+  </Experiment>
+  <HardwareSetting>
+   <ParameterCollection Id="MTBCamera_Preview.See3CAM_130">
+    <ShadingReferenceSource Status="Valid">1</ShadingReferenceSource>
+    <DShowWhiteBalance Status="Valid">6500</DShowWhiteBalance>
+    <AnalogGain Status="Valid">4</AnalogGain>
+    <CameraDisplayName Status="Valid" IsReadOnly="true">PreviewCamera</CameraDisplayName>
+    <ApplyCameraProfile Status="Valid">false</ApplyCameraProfile>
+    <ApplyCameraProfile.Type Status="Valid" IsReadOnly="true">BoolType</ApplyCameraProfile.Type>
+    <ApplyCameraProfile.Default Status="Valid" IsReadOnly="true">false</ApplyCameraProfile.Default>
+    <ApplyImageOrientation Status="Valid">true</ApplyImageOrientation>
+    <ApplyImageOrientation.Type Status="Valid" IsReadOnly="true">BoolType</ApplyImageOrientation.Type>
+    <ApplyImageOrientation.Default Status="Valid" IsReadOnly="true">true</ApplyImageOrientation.Default>
+    <CalculateExposureTimeResult Status="Valid" IsReadOnly="true"/>
+    <CalculateExposureTimeResult.Type Status="Valid" IsReadOnly="true">StringType</CalculateExposureTimeResult.Type>
+    <CalculateExposureTimeResult.Default Status="Valid" IsReadOnly="true"/>
+    <CameraBias Status="Valid" IsReadOnly="true">0</CameraBias>
+    <CameraBias.Type Status="Valid" IsReadOnly="true">IntegerType</CameraBias.Type>
+    <CameraBias.Default Status="Valid" IsReadOnly="true">0</CameraBias.Default>
+    <CameraOrientation Status="Valid" IsReadOnly="true">0</CameraOrientation>
+    <CameraOrientation.Type Status="Valid" IsReadOnly="true">IntegerType</CameraOrientation.Type>
+    <CameraOrientation.ListItems Status="Valid" IsReadOnly="true">0|Original|Original,1|Flip|Flip Horizontally,2|Reverse|Flip Vertically,4|Rotate|Rotate 90 CW,7|FlipReverseRotate|Rotate 90 CCW,3|FlipReverse|Rotate 180,6|ReverseRotate|Mirror at +45 Diagonal,5|FlipRotate|Mirror at -45 Diagonal</CameraOrientation.ListItems>
+    <CameraPixelAccuracy Status="Valid" IsReadOnly="true">0.00390625</CameraPixelAccuracy>
+    <CameraPixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</CameraPixelAccuracy.Type>
+    <CameraPixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</CameraPixelAccuracy.Default>
+    <CameraPixelDistances Status="Valid" IsReadOnly="true">1,1</CameraPixelDistances>
+    <CameraPixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</CameraPixelDistances.Type>
+    <CameraPixelMaximum Status="Valid" IsReadOnly="true">255</CameraPixelMaximum>
+    <CameraPixelMaximum.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelMaximum.Type>
+    <CameraPixelMaximum.Default Status="Valid" IsReadOnly="true">255</CameraPixelMaximum.Default>
+    <CameraPixelMinimum Status="Valid" IsReadOnly="true">0</CameraPixelMinimum>
+    <CameraPixelMinimum.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelMinimum.Type>
+    <CameraPixelMinimum.Default Status="Valid" IsReadOnly="true">0</CameraPixelMinimum.Default>
+    <CameraPixelType Status="Valid" IsReadOnly="true">Bgr24</CameraPixelType>
+    <CameraPixelType.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelType.Type>
+    <CameraPixelType.Default Status="Valid" IsReadOnly="true">0</CameraPixelType.Default>
+    <CameraStatus Status="Valid" IsReadOnly="true"/>
+    <CameraStatus.Type Status="Valid" IsReadOnly="true">StringType</CameraStatus.Type>
+    <CameraStatus.Default Status="Valid" IsReadOnly="true"/>
+    <ExposureTime Status="Valid">20</ExposureTime>
+    <ExposureTime.Type Status="Valid" IsReadOnly="true">DoubleType</ExposureTime.Type>
+    <ExposureTime.Default Status="Valid" IsReadOnly="true">20</ExposureTime.Default>
+    <ExposureTime.Min Status="Valid" IsReadOnly="true">1</ExposureTime.Min>
+    <ExposureTime.Max Status="Valid" IsReadOnly="true">1000</ExposureTime.Max>
+    <ExposureTime.Increment Status="Valid" IsReadOnly="true">1</ExposureTime.Increment>
+    <ExposureTime.GuiHint Status="Valid" IsReadOnly="true">GuiLogSlider</ExposureTime.GuiHint>
+    <Frame Status="Valid">0,0,1920,1080</Frame>
+    <Frame.Type Status="Valid" IsReadOnly="true">RectType</Frame.Type>
+    <Frame.Max Status="Valid" IsReadOnly="true">0,0,1920,1080</Frame.Max>
+    <Frame.GuiHint Status="Valid" IsReadOnly="true">GuiRect</Frame.GuiHint>
+    <ImageByteSize Status="Valid" IsReadOnly="true">6220800</ImageByteSize>
+    <ImageByteSize.Type Status="Valid" IsReadOnly="true">IntegerType</ImageByteSize.Type>
+    <ImageByteSize.Default Status="Valid" IsReadOnly="true">0</ImageByteSize.Default>
+    <ImageFrame Status="Valid" IsReadOnly="true">0,0,1920,1080</ImageFrame>
+    <ImageFrame.Type Status="Valid" IsReadOnly="true">RectType</ImageFrame.Type>
+    <ImageFrame.Max Status="Valid" IsReadOnly="true">0,0,1920,1080</ImageFrame.Max>
+    <ImageOrientation Status="Valid">0</ImageOrientation>
+    <ImageOrientation.Type Status="Valid" IsReadOnly="true">IntegerType</ImageOrientation.Type>
+    <ImageOrientation.ListItems Status="Valid" IsReadOnly="true">0|Original|Original,1|Flip|Flip Horizontally,2|Reverse|Flip Vertically,4|Rotate|Rotate 90 CW,7|FlipReverseRotate|Rotate 90 CCW,3|FlipReverse|Rotate 180,6|ReverseRotate|Mirror at +45 Diagonal,5|FlipRotate|Mirror at -45 Diagonal</ImageOrientation.ListItems>
+    <ImageOrientation.Default Status="Valid" IsReadOnly="true">0</ImageOrientation.Default>
+    <ImageOrientation.Label Status="Valid" IsReadOnly="true">Orientation</ImageOrientation.Label>
+    <ImageOrientation.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ImageOrientation.GuiHint>
+    <ImagePixelAccuracy Status="Valid" IsReadOnly="true">0.00390625</ImagePixelAccuracy>
+    <ImagePixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</ImagePixelAccuracy.Type>
+    <ImagePixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</ImagePixelAccuracy.Default>
+    <ImagePixelDistances Status="Valid" IsReadOnly="true">1,1</ImagePixelDistances>
+    <ImagePixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</ImagePixelDistances.Type>
+    <ImagePixelType Status="Valid" IsReadOnly="true">Bgr24</ImagePixelType>
+    <ImagePixelType.Type Status="Valid" IsReadOnly="true">IntegerType</ImagePixelType.Type>
+    <ImagePixelType.Default Status="Valid" IsReadOnly="true">0</ImagePixelType.Default>
+    <LiveFrame Status="Valid" IsReadOnly="true">0,0,100,100</LiveFrame>
+    <LiveFrame.Type Status="Valid" IsReadOnly="true">RectType</LiveFrame.Type>
+    <LiveImageByteSize Status="Valid" IsReadOnly="true">6220800</LiveImageByteSize>
+    <LiveImageByteSize.Type Status="Valid" IsReadOnly="true">IntegerType</LiveImageByteSize.Type>
+    <LiveImageByteSize.Default Status="Valid" IsReadOnly="true">0</LiveImageByteSize.Default>
+    <LiveImageFrame Status="Valid" IsReadOnly="true">0,0,1920,1080</LiveImageFrame>
+    <LiveImageFrame.Type Status="Valid" IsReadOnly="true">RectType</LiveImageFrame.Type>
+    <LiveImagePixelAccuracy Status="Valid" IsReadOnly="true">0.00390625</LiveImagePixelAccuracy>
+    <LiveImagePixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</LiveImagePixelAccuracy.Type>
+    <LiveImagePixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</LiveImagePixelAccuracy.Default>
+    <LiveImagePixelDistances Status="Valid" IsReadOnly="true">1,1</LiveImagePixelDistances>
+    <LiveImagePixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</LiveImagePixelDistances.Type>
+    <LiveImagePixelType Status="Valid" IsReadOnly="true">Bgr24</LiveImagePixelType>
+    <LiveImagePixelType.Type Status="Valid" IsReadOnly="true">IntegerType</LiveImagePixelType.Type>
+    <LiveImagePixelType.Default Status="Valid" IsReadOnly="true">0</LiveImagePixelType.Default>
+    <LiveValidBits Status="Valid" IsReadOnly="true">8</LiveValidBits>
+    <LiveValidBits.Type Status="Valid" IsReadOnly="true">IntegerType</LiveValidBits.Type>
+    <LiveValidBits.Default Status="Valid" IsReadOnly="true">8</LiveValidBits.Default>
+    <ValidBits Status="Valid" IsReadOnly="true">8</ValidBits>
+    <ValidBits.Type Status="Valid" IsReadOnly="true">IntegerType</ValidBits.Type>
+    <ValidBits.Default Status="Valid" IsReadOnly="true">8</ValidBits.Default>
+    <ValidPixelMaximum Status="Valid" IsReadOnly="true">255</ValidPixelMaximum>
+    <ValidPixelMaximum.Type Status="Valid" IsReadOnly="true">IntegerType</ValidPixelMaximum.Type>
+    <ValidPixelMaximum.Default Status="Valid" IsReadOnly="true">255</ValidPixelMaximum.Default>
+    <CameraDisplayName.Type Status="Valid" IsReadOnly="true">StringType</CameraDisplayName.Type>
+    <CameraDisplayName.Default Status="Valid" IsReadOnly="true"/>
+    <CameraDisplayName.GuiHint Status="Valid" IsReadOnly="true">GuiNone</CameraDisplayName.GuiHint>
+    <CameraDisplayName.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</CameraDisplayName.Mode>
+    <ImageDeliveryBufferCount Status="Valid">4</ImageDeliveryBufferCount>
+    <ImageDeliveryBufferCount.Type Status="Valid" IsReadOnly="true">IntegerType</ImageDeliveryBufferCount.Type>
+    <ImageDeliveryBufferCount.Default Status="Valid" IsReadOnly="true">4</ImageDeliveryBufferCount.Default>
+    <ImageDeliveryBufferCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ImageDeliveryBufferCount.GuiHint>
+    <CameraExtraControlCommandName Status="Valid"/>
+    <CameraExtraControlCommandName.Type Status="Valid" IsReadOnly="true">StringType</CameraExtraControlCommandName.Type>
+    <CameraExtraControlCommandName.Default Status="Valid" IsReadOnly="true"/>
+    <CameraExtraControlCommandName.Mode Status="Valid" IsReadOnly="true">NoPersist</CameraExtraControlCommandName.Mode>
+    <Adjust Status="Valid">1</Adjust>
+    <Adjust.Type Status="Valid" IsReadOnly="true">DoubleType</Adjust.Type>
+    <Adjust.Default Status="Valid" IsReadOnly="true">1</Adjust.Default>
+    <Adjust.Min Status="Valid" IsReadOnly="true">0.05</Adjust.Min>
+    <Adjust.Max Status="Valid" IsReadOnly="true">2</Adjust.Max>
+    <Adjust.Increment Status="Valid" IsReadOnly="true">0.05</Adjust.Increment>
+    <Adjust.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</Adjust.GuiHint>
+    <Adjust.Enabled Status="Valid" IsReadOnly="true">true</Adjust.Enabled>
+    <AdjustFrameRate Status="Valid">true</AdjustFrameRate>
+    <AdjustFrameRate.Type Status="Valid" IsReadOnly="true">BoolType</AdjustFrameRate.Type>
+    <AdjustFrameRate.Default Status="Valid" IsReadOnly="true">true</AdjustFrameRate.Default>
+    <AdjustFrameRate.Label Status="Valid" IsReadOnly="true">Acquire|Adjust Live Frame Rate</AdjustFrameRate.Label>
+    <AdjustFrameRate.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AdjustFrameRate.GuiHint>
+    <AdjustFrameRate.Mode Status="Valid" IsReadOnly="true">Expert</AdjustFrameRate.Mode>
+    <AdjustFrameRate.Enabled Status="Valid" IsReadOnly="true">true</AdjustFrameRate.Enabled>
+    <AdjustFrameRate.DisplayOrder Status="Valid" IsReadOnly="true">201</AdjustFrameRate.DisplayOrder>
+    <AutoExposure Status="Valid">false</AutoExposure>
+    <AutoExposure.Type Status="Valid" IsReadOnly="true">BoolType</AutoExposure.Type>
+    <AutoExposure.Default Status="Valid" IsReadOnly="true">false</AutoExposure.Default>
+    <AutoExposure.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AutoExposure.GuiHint>
+    <AutoExposure.Enabled Status="Valid" IsReadOnly="true">true</AutoExposure.Enabled>
+    <AutoExposureFrame Status="Valid">Empty</AutoExposureFrame>
+    <AutoExposureFrame.Type Status="Valid" IsReadOnly="true">RectType</AutoExposureFrame.Type>
+    <AutoExposureFrame.Default Status="Valid" IsReadOnly="true">Empty</AutoExposureFrame.Default>
+    <AutoExposureFrame.GuiHint Status="Valid" IsReadOnly="true">GuiNone</AutoExposureFrame.GuiHint>
+    <AutoExposureFrame.Enabled Status="Valid" IsReadOnly="true">true</AutoExposureFrame.Enabled>
+    <Binning Status="Valid">1,1</Binning>
+    <Binning.Type Status="Valid" IsReadOnly="true">SizeType</Binning.Type>
+    <Binning.Default Status="Valid" IsReadOnly="true">1,1</Binning.Default>
+    <Binning.GuiHint Status="Valid" IsReadOnly="true">GuiNone</Binning.GuiHint>
+    <BinningList Status="Valid">0</BinningList>
+    <BinningList.Type Status="Valid" IsReadOnly="true">IntegerType</BinningList.Type>
+    <BinningList.ListItems Status="Valid" IsReadOnly="true">0|1x1|1x1</BinningList.ListItems>
+    <BinningList.Default Status="Valid" IsReadOnly="true">0</BinningList.Default>
+    <BinningList.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</BinningList.GuiHint>
+    <BlackReference Status="Valid">false</BlackReference>
+    <BlackReference.Type Status="Valid" IsReadOnly="true">BoolType</BlackReference.Type>
+    <BlackReference.Default Status="Valid" IsReadOnly="true">false</BlackReference.Default>
+    <BlackReference.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</BlackReference.GuiHint>
+    <BlackReference.Enabled Status="Valid" IsReadOnly="true">false</BlackReference.Enabled>
+    <DefaultDisplayGamma Status="Valid">1</DefaultDisplayGamma>
+    <DefaultDisplayGamma.Type Status="Valid" IsReadOnly="true">DoubleType</DefaultDisplayGamma.Type>
+    <DefaultDisplayGamma.Default Status="Valid" IsReadOnly="true">1</DefaultDisplayGamma.Default>
+    <DefaultDisplayGamma.Min Status="Valid" IsReadOnly="true">0.3</DefaultDisplayGamma.Min>
+    <DefaultDisplayGamma.Max Status="Valid" IsReadOnly="true">3</DefaultDisplayGamma.Max>
+    <DefaultDisplayGamma.Increment Status="Valid" IsReadOnly="true">0.01</DefaultDisplayGamma.Increment>
+    <DefaultDisplayGamma.Mode Status="Valid" IsReadOnly="true">NoPersist</DefaultDisplayGamma.Mode>
+    <DefaultDisplayGamma.GuiHint Status="Valid" IsReadOnly="true">GuiNone</DefaultDisplayGamma.GuiHint>
+    <DualCameraCalibration Status="Valid">false</DualCameraCalibration>
+    <DualCameraCalibration.Type Status="Valid" IsReadOnly="true">BoolType</DualCameraCalibration.Type>
+    <DualCameraCalibration.Default Status="Valid" IsReadOnly="true">false</DualCameraCalibration.Default>
+    <DualCameraCalibration.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DualCameraCalibration.GuiHint>
+    <DualCameraCalibrationId Status="Valid"/>
+    <DualCameraCalibration.Enabled Status="Valid" IsReadOnly="true">false</DualCameraCalibration.Enabled>
+    <ExposureDelay Status="Valid">0</ExposureDelay>
+    <ExposureDelay.Type Status="Valid" IsReadOnly="true">DoubleType</ExposureDelay.Type>
+    <ExposureDelay.Default Status="Valid" IsReadOnly="true">0</ExposureDelay.Default>
+    <ExposureDelay.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ExposureDelay.GuiHint>
+    <ExposureDelay.Max Status="Valid" IsReadOnly="true">1000</ExposureDelay.Max>
+    <CalculateExposureMaximum Status="Valid">10000</CalculateExposureMaximum>
+    <CalculateExposureMaximum.Type Status="Valid" IsReadOnly="true">DoubleType</CalculateExposureMaximum.Type>
+    <CalculateExposureMaximum.Default Status="Valid" IsReadOnly="true">10000</CalculateExposureMaximum.Default>
+    <CalculateExposureMaximum.Min Status="Valid" IsReadOnly="true">10</CalculateExposureMaximum.Min>
+    <CalculateExposureMaximum.Max Status="Valid" IsReadOnly="true">10000</CalculateExposureMaximum.Max>
+    <CalculateExposureMaximum.Increment Status="Valid" IsReadOnly="true">1</CalculateExposureMaximum.Increment>
+    <CalculateExposureMaximum.Enabled Status="Valid" IsReadOnly="true">true</CalculateExposureMaximum.Enabled>
+    <CalculateExposureMaximum.GuiHint Status="Valid" IsReadOnly="true">GuiNone</CalculateExposureMaximum.GuiHint>
+    <AutoExposureTolerance Status="Valid">0.05</AutoExposureTolerance>
+    <AutoExposureTolerance.Type Status="Valid" IsReadOnly="true">DoubleType</AutoExposureTolerance.Type>
+    <AutoExposureTolerance.Default Status="Valid" IsReadOnly="true">0.05</AutoExposureTolerance.Default>
+    <AutoExposureTolerance.Min Status="Valid" IsReadOnly="true">0</AutoExposureTolerance.Min>
+    <AutoExposureTolerance.Max Status="Valid" IsReadOnly="true">10</AutoExposureTolerance.Max>
+    <AutoExposureTolerance.Increment Status="Valid" IsReadOnly="true">1E-06</AutoExposureTolerance.Increment>
+    <AutoExposureTolerance.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</AutoExposureTolerance.GuiHint>
+    <AutoExposureTolerance.Mode Status="Valid" IsReadOnly="true">Debug</AutoExposureTolerance.Mode>
+    <AutoExposureTolerance.Enabled Status="Valid" IsReadOnly="true">true</AutoExposureTolerance.Enabled>
+    <FrameRate Status="Valid" IsReadOnly="true">0</FrameRate>
+    <FrameRate.Type Status="Valid" IsReadOnly="true">DoubleType</FrameRate.Type>
+    <FrameRate.Default Status="Valid" IsReadOnly="true">0</FrameRate.Default>
+    <FrameRate.Label Status="Valid" IsReadOnly="true">Acquire|Live Frame Rate</FrameRate.Label>
+    <FrameRate.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</FrameRate.GuiHint>
+    <FrameRate.Mode Status="Valid" IsReadOnly="true">Expert</FrameRate.Mode>
+    <FrameRate.DisplayOrder Status="Valid" IsReadOnly="true">203</FrameRate.DisplayOrder>
+    <FrameRateTarget Status="Valid">30</FrameRateTarget>
+    <FrameRateTarget.Type Status="Valid" IsReadOnly="true">DoubleType</FrameRateTarget.Type>
+    <FrameRateTarget.Default Status="Valid" IsReadOnly="true">30</FrameRateTarget.Default>
+    <FrameRateTarget.Min Status="Valid" IsReadOnly="true">1</FrameRateTarget.Min>
+    <FrameRateTarget.Max Status="Valid" IsReadOnly="true">100</FrameRateTarget.Max>
+    <FrameRateTarget.Increment Status="Valid" IsReadOnly="true">1</FrameRateTarget.Increment>
+    <FrameRateTarget.Label Status="Valid" IsReadOnly="true">Acquire|Live Frame Rate Max</FrameRateTarget.Label>
+    <FrameRateTarget.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</FrameRateTarget.GuiHint>
+    <FrameRateTarget.Mode Status="Valid" IsReadOnly="true">Expert</FrameRateTarget.Mode>
+    <FrameRateTarget.Enabled Status="Valid" IsReadOnly="true">true</FrameRateTarget.Enabled>
+    <FrameRateTarget.DisplayOrder Status="Valid" IsReadOnly="true">202</FrameRateTarget.DisplayOrder>
+    <ImageOrientation.Enabled Status="Valid" IsReadOnly="true">true</ImageOrientation.Enabled>
+    <NoiseFilter Status="Valid">false</NoiseFilter>
+    <NoiseFilter.Type Status="Valid" IsReadOnly="true">BoolType</NoiseFilter.Type>
+    <NoiseFilter.Default Status="Valid" IsReadOnly="true">false</NoiseFilter.Default>
+    <NoiseFilter.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</NoiseFilter.GuiHint>
+    <NoiseFilterThreshold Status="Valid">1.5</NoiseFilterThreshold>
+    <NoiseFilterThreshold.Type Status="Valid" IsReadOnly="true">DoubleType</NoiseFilterThreshold.Type>
+    <NoiseFilterThreshold.Default Status="Valid" IsReadOnly="true">1.5</NoiseFilterThreshold.Default>
+    <NoiseFilterThreshold.Min Status="Valid" IsReadOnly="true">0</NoiseFilterThreshold.Min>
+    <NoiseFilterThreshold.Max Status="Valid" IsReadOnly="true">10</NoiseFilterThreshold.Max>
+    <NoiseFilterThreshold.Increment Status="Valid" IsReadOnly="true">0.1</NoiseFilterThreshold.Increment>
+    <NoiseFilterThreshold.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</NoiseFilterThreshold.GuiHint>
+    <NoiseFilter.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilter.Enabled>
+    <NoiseFilterThreshold.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilterThreshold.Enabled>
+    <NoiseFilterWithIPP Status="Valid">false</NoiseFilterWithIPP>
+    <NoiseFilterWithIPP.Type Status="Valid" IsReadOnly="true">BoolType</NoiseFilterWithIPP.Type>
+    <NoiseFilterWithIPP.Default Status="Valid" IsReadOnly="true">false</NoiseFilterWithIPP.Default>
+    <NoiseFilterWithIPP.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilterWithIPP.Enabled>
+    <NoiseFilterWithIPP.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</NoiseFilterWithIPP.GuiHint>
+    <NoiseFilterWithIPP.Mode Status="Valid" IsReadOnly="true">Debug</NoiseFilterWithIPP.Mode>
+    <CenteredYFrame Status="Valid">false</CenteredYFrame>
+    <CenteredYFrame.Type Status="Valid" IsReadOnly="true">BoolType</CenteredYFrame.Type>
+    <CenteredYFrame.Default Status="Valid" IsReadOnly="true">false</CenteredYFrame.Default>
+    <CenteredYFrame.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</CenteredYFrame.GuiHint>
+    <CenteredYFrame.Mode Status="Valid" IsReadOnly="true">Debug</CenteredYFrame.Mode>
+    <ReferenceImageCount Status="Valid">3</ReferenceImageCount>
+    <ReferenceImageCount.Type Status="Valid" IsReadOnly="true">IntegerType</ReferenceImageCount.Type>
+    <ReferenceImageCount.Default Status="Valid" IsReadOnly="true">3</ReferenceImageCount.Default>
+    <ReferenceImageCount.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</ReferenceImageCount.GuiHint>
+    <ReferenceImageCount.Label Status="Valid" IsReadOnly="true">Post Processing|Reference Image Count</ReferenceImageCount.Label>
+    <ReferenceImageCount.Enabled Status="Valid" IsReadOnly="true">true</ReferenceImageCount.Enabled>
+    <ReferenceImageCount.Min Status="Valid" IsReadOnly="true">1</ReferenceImageCount.Min>
+    <ReferenceImageCount.Max Status="Valid" IsReadOnly="true">5</ReferenceImageCount.Max>
+    <ReferenceImageCount.Increment Status="Valid" IsReadOnly="true">1</ReferenceImageCount.Increment>
+    <ReferenceImageCount.Mode Status="Valid" IsReadOnly="true">Expert</ReferenceImageCount.Mode>
+    <ShadingReference Status="Valid">false</ShadingReference>
+    <ShadingReference.Type Status="Valid" IsReadOnly="true">BoolType</ShadingReference.Type>
+    <ShadingReference.Default Status="Valid" IsReadOnly="true">false</ShadingReference.Default>
+    <ShadingReference.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ShadingReference.GuiHint>
+    <ShadingReferenceSource.Type Status="Valid" IsReadOnly="true">IntegerType</ShadingReferenceSource.Type>
+    <ShadingReferenceSource.ListItems Status="Valid" IsReadOnly="true">0|Global|Global,1|Specific|Specific,2|CellDiscoverer|CellDiscoverer</ShadingReferenceSource.ListItems>
+    <ShadingReferenceSource.Default Status="Valid" IsReadOnly="true">1</ShadingReferenceSource.Default>
+    <ShadingReferenceSource.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ShadingReferenceSource.GuiHint>
+    <ShadingReferenceSourceVisibility Status="Valid">true</ShadingReferenceSourceVisibility>
+    <ShadingReferenceSourceVisibility.Type Status="Valid" IsReadOnly="true">BoolType</ShadingReferenceSourceVisibility.Type>
+    <ShadingReferenceSourceVisibility.Default Status="Valid" IsReadOnly="true">true</ShadingReferenceSourceVisibility.Default>
+    <ShadingReferenceSourceVisibility.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ShadingReferenceSourceVisibility.GuiHint>
+    <ShadingReferenceSourceVisibility.Mode Status="Valid" IsReadOnly="true">NoPersist</ShadingReferenceSourceVisibility.Mode>
+    <ShadingReference.Enabled Status="Valid" IsReadOnly="true">false</ShadingReference.Enabled>
+    <ShadingStrength Status="Valid">1</ShadingStrength>
+    <ShadingStrength.Type Status="Valid" IsReadOnly="true">DoubleType</ShadingStrength.Type>
+    <ShadingStrength.Default Status="Valid" IsReadOnly="true">1</ShadingStrength.Default>
+    <ShadingStrength.Min Status="Valid" IsReadOnly="true">0.1</ShadingStrength.Min>
+    <ShadingStrength.Max Status="Valid" IsReadOnly="true">2</ShadingStrength.Max>
+    <ShadingStrength.Increment Status="Valid" IsReadOnly="true">0.01</ShadingStrength.Increment>
+    <ShadingStrength.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</ShadingStrength.GuiHint>
+    <ShadingStrength.Mode Status="Valid" IsReadOnly="true">Expert</ShadingStrength.Mode>
+    <ShadingStrength.Enabled Status="Valid" IsReadOnly="true">true</ShadingStrength.Enabled>
+    <ShadingStrength.Label Status="Valid" IsReadOnly="true">Post Processing|Shading Strength</ShadingStrength.Label>
+    <ShadingUseBias Status="Valid">true</ShadingUseBias>
+    <ShadingUseBias.Type Status="Valid" IsReadOnly="true">BoolType</ShadingUseBias.Type>
+    <ShadingUseBias.Default Status="Valid" IsReadOnly="true">true</ShadingUseBias.Default>
+    <ShadingUseBias.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ShadingUseBias.GuiHint>
+    <ShadingUseBias.Mode Status="Valid" IsReadOnly="true">Expert</ShadingUseBias.Mode>
+    <ShadingUseBias.Enabled Status="Valid" IsReadOnly="true">true</ShadingUseBias.Enabled>
+    <ShadingUseBias.Label Status="Valid" IsReadOnly="true">Post Processing|Shading Use Bias</ShadingUseBias.Label>
+    <UnsharpMask Status="Valid">false</UnsharpMask>
+    <UnsharpMask.Type Status="Valid" IsReadOnly="true">BoolType</UnsharpMask.Type>
+    <UnsharpMask.Default Status="Valid" IsReadOnly="true">false</UnsharpMask.Default>
+    <UnsharpMask.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</UnsharpMask.GuiHint>
+    <UnsharpMaskState Status="Valid">
+     <UnsharpMask>
+      <ColorMode>1</ColorMode>
+      <AutoContrastMode>0</AutoContrastMode>
+      <ThresholdMode>1</ThresholdMode>
+      <Strength>1</Strength>
+      <Radius>2</Radius>
+      <LowThreshold>0</LowThreshold>
+      <HighThreshold>100</HighThreshold>
+      <AutoContrastTolerance>1</AutoContrastTolerance>
+      <ClipToValidBits>true</ClipToValidBits>
+      <PerformInPlace>false</PerformInPlace>
+     </UnsharpMask>
+    </UnsharpMaskState>
+    <UnsharpMaskState.Type Status="Valid" IsReadOnly="true">StringType</UnsharpMaskState.Type>
+    <UnsharpMaskState.Default Status="Valid" IsReadOnly="true"/>
+    <UnsharpMask.Enabled Status="Valid" IsReadOnly="true">true</UnsharpMask.Enabled>
+    <ImageOrientationWithIPP Status="Valid">true</ImageOrientationWithIPP>
+    <ImageOrientationWithIPP.Type Status="Valid" IsReadOnly="true">BoolType</ImageOrientationWithIPP.Type>
+    <ImageOrientationWithIPP.Default Status="Valid" IsReadOnly="true">true</ImageOrientationWithIPP.Default>
+    <ImageOrientationWithIPP.Enabled Status="Valid" IsReadOnly="true">true</ImageOrientationWithIPP.Enabled>
+    <ImageOrientationWithIPP.Mode Status="Valid" IsReadOnly="true">Debug</ImageOrientationWithIPP.Mode>
+    <ImageOrientationWithIPP.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ImageOrientationWithIPP.GuiHint>
+    <ContinuousAcquisitionMode Status="Valid">0</ContinuousAcquisitionMode>
+    <ContinuousAcquisitionMode.Type Status="Valid" IsReadOnly="true">IntegerType</ContinuousAcquisitionMode.Type>
+    <ContinuousAcquisitionMode.ListItems Status="Valid" IsReadOnly="true">0|Normal|Normal,1|Burst|Burst</ContinuousAcquisitionMode.ListItems>
+    <ContinuousAcquisitionMode.Default Status="Valid" IsReadOnly="true">0</ContinuousAcquisitionMode.Default>
+    <SequenceCount Status="Valid">0</SequenceCount>
+    <SequenceCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</SequenceCount.GuiHint>
+    <SequenceCount.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</SequenceCount.Mode>
+    <SequenceProgress Status="Valid">true</SequenceProgress>
+    <SequenceProgress.Type Status="Valid" IsReadOnly="true">BoolType</SequenceProgress.Type>
+    <SequenceProgress.Default Status="Valid" IsReadOnly="true">true</SequenceProgress.Default>
+    <SequenceProgress.GuiHint Status="Valid" IsReadOnly="true">GuiNone</SequenceProgress.GuiHint>
+    <ContinuousAcquisitionMode.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ContinuousAcquisitionMode.GuiHint>
+    <ContinuousAcquisitionMode.Mode Status="Valid" IsReadOnly="true">NoPersist</ContinuousAcquisitionMode.Mode>
+    <ExposureTime.Enabled Status="Valid" IsReadOnly="true">true</ExposureTime.Enabled>
+    <ColorMode Status="Valid">1</ColorMode>
+    <ColorMode.Type Status="Valid" IsReadOnly="true">IntegerType</ColorMode.Type>
+    <ColorMode.ListItems Status="Valid" IsReadOnly="true">0|0|Monochrome,1|1|Color</ColorMode.ListItems>
+    <ColorMode.Default Status="Valid" IsReadOnly="true">1</ColorMode.Default>
+    <ColorMode.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ColorMode.GuiHint>
+    <ColorMode.Enabled Status="Valid" IsReadOnly="true">false</ColorMode.Enabled>
+    <DShowWhiteBalance.Type Status="Valid" IsReadOnly="true">IntegerType</DShowWhiteBalance.Type>
+    <DShowWhiteBalance.Default Status="Valid" IsReadOnly="true">5000</DShowWhiteBalance.Default>
+    <DShowWhiteBalance.Min Status="Valid" IsReadOnly="true">1000</DShowWhiteBalance.Min>
+    <DShowWhiteBalance.Max Status="Valid" IsReadOnly="true">10000</DShowWhiteBalance.Max>
+    <DShowWhiteBalance.Increment Status="Valid" IsReadOnly="true">50</DShowWhiteBalance.Increment>
+    <DShowWhiteBalance.Enabled Status="Valid" IsReadOnly="true">true</DShowWhiteBalance.Enabled>
+    <DShowWhiteBalance.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</DShowWhiteBalance.GuiHint>
+    <DShowWhiteBalance.Mode Status="Valid" IsReadOnly="true">Normal</DShowWhiteBalance.Mode>
+    <DShowWhiteBalance.Label Status="Valid" IsReadOnly="true">White Balance</DShowWhiteBalance.Label>
+    <DShowAutoWhiteBalance Status="Valid">false</DShowAutoWhiteBalance>
+    <DShowAutoWhiteBalance.Type Status="Valid" IsReadOnly="true">BoolType</DShowAutoWhiteBalance.Type>
+    <DShowAutoWhiteBalance.Default Status="Valid" IsReadOnly="true">false</DShowAutoWhiteBalance.Default>
+    <DShowAutoWhiteBalance.Enabled Status="Valid" IsReadOnly="true">true</DShowAutoWhiteBalance.Enabled>
+    <DShowAutoWhiteBalance.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DShowAutoWhiteBalance.GuiHint>
+    <DShowAutoWhiteBalance.Mode Status="Valid" IsReadOnly="true">Normal</DShowAutoWhiteBalance.Mode>
+    <DShowAutoWhiteBalance.Label Status="Valid" IsReadOnly="true">Auto White Balance</DShowAutoWhiteBalance.Label>
+    <CameraGamma Status="Valid">2.2</CameraGamma>
+    <CameraGamma.Type Status="Valid" IsReadOnly="true">DoubleType</CameraGamma.Type>
+    <CameraGamma.Default Status="Valid" IsReadOnly="true">2.2</CameraGamma.Default>
+    <CameraGamma.Min Status="Valid" IsReadOnly="true">0.4</CameraGamma.Min>
+    <CameraGamma.Max Status="Valid" IsReadOnly="true">5</CameraGamma.Max>
+    <CameraGamma.Increment Status="Valid" IsReadOnly="true">0.01</CameraGamma.Increment>
+    <CameraGamma.Enabled Status="Valid" IsReadOnly="true">true</CameraGamma.Enabled>
+    <AnalogGain.Type Status="Valid" IsReadOnly="true">DoubleType</AnalogGain.Type>
+    <AnalogGain.Default Status="Valid" IsReadOnly="true">2</AnalogGain.Default>
+    <AnalogGain.Min Status="Valid" IsReadOnly="true">0</AnalogGain.Min>
+    <AnalogGain.Max Status="Valid" IsReadOnly="true">100</AnalogGain.Max>
+    <AnalogGain.Increment Status="Valid" IsReadOnly="true">1</AnalogGain.Increment>
+    <AnalogGain.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</AnalogGain.GuiHint>
+    <AnalogGain.Enabled Status="Valid" IsReadOnly="true">true</AnalogGain.Enabled>
+    <DShowIgnoredImagesCountForSnap Status="Valid">3</DShowIgnoredImagesCountForSnap>
+    <DShowIgnoredImagesCountForSnap.Type Status="Valid" IsReadOnly="true">IntegerType</DShowIgnoredImagesCountForSnap.Type>
+    <DShowIgnoredImagesCountForSnap.Default Status="Valid" IsReadOnly="true">3</DShowIgnoredImagesCountForSnap.Default>
+    <DShowIgnoredImagesCountForSnap.Min Status="Valid" IsReadOnly="true">0</DShowIgnoredImagesCountForSnap.Min>
+    <DShowIgnoredImagesCountForSnap.Max Status="Valid" IsReadOnly="true">100</DShowIgnoredImagesCountForSnap.Max>
+    <DShowIgnoredImagesCountForSnap.Increment Status="Valid" IsReadOnly="true">1</DShowIgnoredImagesCountForSnap.Increment>
+    <DShowIgnoredImagesCountForSnap.Enabled Status="Valid" IsReadOnly="true">true</DShowIgnoredImagesCountForSnap.Enabled>
+    <DShowIgnoredImagesCountForSnap.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</DShowIgnoredImagesCountForSnap.GuiHint>
+    <DShowIgnoredImagesCountForSnap.Mode Status="Valid" IsReadOnly="true">Expert</DShowIgnoredImagesCountForSnap.Mode>
+    <DShowIgnoredImagesCountForSnap.Label Status="Valid" IsReadOnly="true">Ignored Images</DShowIgnoredImagesCountForSnap.Label>
+    <DShowMaxLostFramesException Status="Valid">4</DShowMaxLostFramesException>
+    <DShowMaxLostFramesException.Type Status="Valid" IsReadOnly="true">IntegerType</DShowMaxLostFramesException.Type>
+    <DShowMaxLostFramesException.Default Status="Valid" IsReadOnly="true">4</DShowMaxLostFramesException.Default>
+    <DShowMaxLostFramesException.Min Status="Valid" IsReadOnly="true">-1</DShowMaxLostFramesException.Min>
+    <DShowMaxLostFramesException.Max Status="Valid" IsReadOnly="true">100</DShowMaxLostFramesException.Max>
+    <DShowMaxLostFramesException.Increment Status="Valid" IsReadOnly="true">1</DShowMaxLostFramesException.Increment>
+    <DShowMaxLostFramesException.Enabled Status="Valid" IsReadOnly="true">true</DShowMaxLostFramesException.Enabled>
+    <DShowMaxLostFramesException.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</DShowMaxLostFramesException.GuiHint>
+    <DShowMaxLostFramesException.Mode Status="Valid" IsReadOnly="true">Expert</DShowMaxLostFramesException.Mode>
+    <DShowMaxLostFramesException.Label Status="Valid" IsReadOnly="true">Max Lost frames</DShowMaxLostFramesException.Label>
+    <DShowCaptureState Status="Valid">false</DShowCaptureState>
+    <DShowCaptureState.Type Status="Valid" IsReadOnly="true">BoolType</DShowCaptureState.Type>
+    <DShowCaptureState.Default Status="Valid" IsReadOnly="true">false</DShowCaptureState.Default>
+    <DShowCaptureState.Enabled Status="Valid" IsReadOnly="true">true</DShowCaptureState.Enabled>
+    <DShowCaptureState.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DShowCaptureState.GuiHint>
+    <DShowCaptureState.Mode Status="Valid" IsReadOnly="true">Expert</DShowCaptureState.Mode>
+    <DShowCaptureState.Label Status="Valid" IsReadOnly="true">Capture State</DShowCaptureState.Label>
+    <LostFrames Status="Valid" IsReadOnly="true">0</LostFrames>
+    <LostFrames.Type Status="Valid" IsReadOnly="true">IntegerType</LostFrames.Type>
+    <LostFrames.Default Status="Valid" IsReadOnly="true">0</LostFrames.Default>
+    <LostFrames.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</LostFrames.GuiHint>
+    <LostFrames.Mode Status="Valid" IsReadOnly="true">Expert</LostFrames.Mode>
+    <Trigger Status="Valid">false</Trigger>
+    <Trigger.Type Status="Valid" IsReadOnly="true">BoolType</Trigger.Type>
+    <Trigger.Default Status="Valid" IsReadOnly="true">false</Trigger.Default>
+    <Trigger.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</Trigger.GuiHint>
+    <Trigger.Enabled Status="Valid" IsReadOnly="true">true</Trigger.Enabled>
+    <DShowEconProcessImages Status="Valid">true</DShowEconProcessImages>
+    <DShowEconProcessImages.Type Status="Valid" IsReadOnly="true">BoolType</DShowEconProcessImages.Type>
+    <DShowEconProcessImages.Default Status="Valid" IsReadOnly="true">true</DShowEconProcessImages.Default>
+    <DShowEconProcessImages.Enabled Status="Valid" IsReadOnly="true">true</DShowEconProcessImages.Enabled>
+    <DShowEconProcessImages.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DShowEconProcessImages.GuiHint>
+    <DShowEconProcessImages.Mode Status="Valid" IsReadOnly="true">Expert</DShowEconProcessImages.Mode>
+    <DShowEconProcessImages.Label Status="Valid" IsReadOnly="true">Process Images</DShowEconProcessImages.Label>
+    <DShowProcessImagesDuringAcquisition Status="Valid">true</DShowProcessImagesDuringAcquisition>
+    <DShowProcessImagesDuringAcquisition.Type Status="Valid" IsReadOnly="true">BoolType</DShowProcessImagesDuringAcquisition.Type>
+    <DShowProcessImagesDuringAcquisition.Default Status="Valid" IsReadOnly="true">true</DShowProcessImagesDuringAcquisition.Default>
+    <DShowProcessImagesDuringAcquisition.Enabled Status="Valid" IsReadOnly="true">true</DShowProcessImagesDuringAcquisition.Enabled>
+    <DShowProcessImagesDuringAcquisition.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DShowProcessImagesDuringAcquisition.GuiHint>
+    <DShowProcessImagesDuringAcquisition.Mode Status="Valid" IsReadOnly="true">Expert</DShowProcessImagesDuringAcquisition.Mode>
+    <DShowProcessImagesDuringAcquisition.Label Status="Valid" IsReadOnly="true">Parallel Processing</DShowProcessImagesDuringAcquisition.Label>
+    <DShowSaveRawImages Status="Valid">false</DShowSaveRawImages>
+    <DShowSaveRawImages.Type Status="Valid" IsReadOnly="true">BoolType</DShowSaveRawImages.Type>
+    <DShowSaveRawImages.Default Status="Valid" IsReadOnly="true">false</DShowSaveRawImages.Default>
+    <DShowSaveRawImages.Enabled Status="Valid" IsReadOnly="true">true</DShowSaveRawImages.Enabled>
+    <DShowSaveRawImages.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DShowSaveRawImages.GuiHint>
+    <DShowSaveRawImages.Mode Status="Valid" IsReadOnly="true">Expert</DShowSaveRawImages.Mode>
+    <DShowSaveRawImages.Label Status="Valid" IsReadOnly="true">Save Raw Images</DShowSaveRawImages.Label>
+    <BadFramesCount Status="Valid" IsReadOnly="true">3</BadFramesCount>
+    <BadFramesCount.Type Status="Valid" IsReadOnly="true">IntegerType</BadFramesCount.Type>
+    <BadFramesCount.Default Status="Valid" IsReadOnly="true">3</BadFramesCount.Default>
+    <BadFramesCount.Min Status="Valid" IsReadOnly="true">0</BadFramesCount.Min>
+    <BadFramesCount.Max Status="Valid" IsReadOnly="true">100</BadFramesCount.Max>
+    <BadFramesCount.Increment Status="Valid" IsReadOnly="true">1</BadFramesCount.Increment>
+    <BadFramesCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</BadFramesCount.GuiHint>
+    <LedContrastSensitivity2 Status="Valid">1</LedContrastSensitivity2>
+    <LedContrastSensitivity2.Type Status="Valid" IsReadOnly="true">DoubleType</LedContrastSensitivity2.Type>
+    <LedContrastSensitivity2.Default Status="Valid" IsReadOnly="true">1</LedContrastSensitivity2.Default>
+    <LedContrastSensitivity2.Min Status="Valid" IsReadOnly="true">0</LedContrastSensitivity2.Min>
+    <LedContrastSensitivity2.Max Status="Valid" IsReadOnly="true">99</LedContrastSensitivity2.Max>
+    <LedContrastSensitivity2.Increment Status="Valid" IsReadOnly="true">0.01</LedContrastSensitivity2.Increment>
+    <LedContrastSensitivity2.Enabled Status="Valid" IsReadOnly="true">true</LedContrastSensitivity2.Enabled>
+    <LedContrastSensitivity2.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</LedContrastSensitivity2.GuiHint>
+    <LedContrastSensitivity2.Mode Status="Valid" IsReadOnly="true">Expert</LedContrastSensitivity2.Mode>
+    <LedContrastSensitivity2.Label Status="Valid" IsReadOnly="true">Sensitivity 2</LedContrastSensitivity2.Label>
+    <LedContrastSensitivity3 Status="Valid">2.5</LedContrastSensitivity3>
+    <LedContrastSensitivity3.Type Status="Valid" IsReadOnly="true">DoubleType</LedContrastSensitivity3.Type>
+    <LedContrastSensitivity3.Default Status="Valid" IsReadOnly="true">2.5</LedContrastSensitivity3.Default>
+    <LedContrastSensitivity3.Min Status="Valid" IsReadOnly="true">0</LedContrastSensitivity3.Min>
+    <LedContrastSensitivity3.Max Status="Valid" IsReadOnly="true">99</LedContrastSensitivity3.Max>
+    <LedContrastSensitivity3.Increment Status="Valid" IsReadOnly="true">0.01</LedContrastSensitivity3.Increment>
+    <LedContrastSensitivity3.Enabled Status="Valid" IsReadOnly="true">true</LedContrastSensitivity3.Enabled>
+    <LedContrastSensitivity3.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</LedContrastSensitivity3.GuiHint>
+    <LedContrastSensitivity3.Mode Status="Valid" IsReadOnly="true">Expert</LedContrastSensitivity3.Mode>
+    <LedContrastSensitivity3.Label Status="Valid" IsReadOnly="true">Sensitivity 3</LedContrastSensitivity3.Label>
+    <StrobeSignal Status="Valid">false</StrobeSignal>
+    <StrobeSignal.Type Status="Valid" IsReadOnly="true">BoolType</StrobeSignal.Type>
+    <StrobeSignal.Default Status="Valid" IsReadOnly="true">false</StrobeSignal.Default>
+    <StrobeSignal.Enabled Status="Valid" IsReadOnly="true">true</StrobeSignal.Enabled>
+    <StrobeSignal.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</StrobeSignal.GuiHint>
+    <StrobeSignal.Mode Status="Valid" IsReadOnly="true">Expert</StrobeSignal.Mode>
+    <StrobeSignal.Label Status="Valid" IsReadOnly="true">Strobe Signal</StrobeSignal.Label>
+    <ResetEconUSBCommand Status="Valid"/>
+    <ResetEconUSBCommand.Type Status="Valid" IsReadOnly="true">StringType</ResetEconUSBCommand.Type>
+    <ResetEconUSBCommand.Default Status="Valid" IsReadOnly="true"/>
+    <ResetEconUSBCommand.Enabled Status="Valid" IsReadOnly="true">true</ResetEconUSBCommand.Enabled>
+    <ResetEconUSBCommand.Label Status="Valid" IsReadOnly="true">USB Reset</ResetEconUSBCommand.Label>
+    <ResetEconUSBCommand.GuiHint Status="Valid" IsReadOnly="true">GuiButton</ResetEconUSBCommand.GuiHint>
+    <ResetEconUSBCommand.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</ResetEconUSBCommand.Mode>
+    <Frame.Enabled Status="Valid" IsReadOnly="true">false</Frame.Enabled>
+    <SequenceCount.Enabled Status="Valid" IsReadOnly="true">false</SequenceCount.Enabled>
+    <LiveImageFrame.Max Status="Valid" IsReadOnly="true">0,0,1920,1080</LiveImageFrame.Max>
+    <CameraIdentifier Status="Valid" IsReadOnly="true">See3CAM_130_20084A06</CameraIdentifier>
+    <CameraIdentifier.Type Status="Valid" IsReadOnly="true">StringType</CameraIdentifier.Type>
+    <CameraIdentifier.Default Status="Valid" IsReadOnly="true"/>
+    <CameraIdentifier.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</CameraIdentifier.GuiHint>
+    <CameraIdentifier.DisplayOrder Status="Valid" IsReadOnly="true">-999</CameraIdentifier.DisplayOrder>
+    <CameraIdentifier.Label Status="Valid" IsReadOnly="true">Camera Identifier</CameraIdentifier.Label>
+    <AutomaticTriggerControl Status="Valid">true</AutomaticTriggerControl>
+    <AutomaticTriggerControl.Type Status="Valid" IsReadOnly="true">BoolType</AutomaticTriggerControl.Type>
+    <AutomaticTriggerControl.Default Status="Valid" IsReadOnly="true">true</AutomaticTriggerControl.Default>
+    <AutomaticTriggerControl.Enabled Status="Valid" IsReadOnly="true">true</AutomaticTriggerControl.Enabled>
+    <AutomaticTriggerControl.Label Status="Valid" IsReadOnly="true">Acquire|Auto Trigger Control</AutomaticTriggerControl.Label>
+    <AutomaticTriggerControl.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</AutomaticTriggerControl.Mode>
+    <AutomaticTriggerControl.GuiHint Status="Valid" IsReadOnly="true">GuiNone</AutomaticTriggerControl.GuiHint>
+    <TheoreticalTotalMagnification Status="Valid" IsActivated="true" IsReadOnly="true">1</TheoreticalTotalMagnification>
+    <TotalMagnification Status="Valid" IsActivated="true" IsReadOnly="true">1</TotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsActivated="true" IsReadOnly="true">µm</DefaultScalingUnit>
+    <RoiCenterOffsetX Status="Valid" IsActivated="true" IsReadOnly="true">0</RoiCenterOffsetX>
+    <RoiCenterOffsetY Status="Valid" IsActivated="true" IsReadOnly="true">0</RoiCenterOffsetY>
+    <TotalAperture Status="Valid" IsActivated="true" IsReadOnly="true">1.4</TotalAperture>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+    <Temperature Status="Valid" IsReadOnly="true">18</Temperature>
+    <CoolingPowerInfo Status="SuperValid" IsReadOnly="true">23 / 87</CoolingPowerInfo>
+    <ExposureTime Status="Valid">5</ExposureTime>
+    <ImageOrientation Status="Valid">3</ImageOrientation>
+    <AnalogGainModeList Status="Valid">2</AnalogGainModeList>
+    <Adjust Status="Valid">0.6</Adjust>
+    <FrameRateTarget Status="Valid">12</FrameRateTarget>
+    <CameraDisplayName Status="Valid" IsReadOnly="true">Axiocam 705 mono</CameraDisplayName>
+    <ApplyCameraProfile Status="Valid">false</ApplyCameraProfile>
+    <ApplyCameraProfile.Type Status="Valid" IsReadOnly="true">BoolType</ApplyCameraProfile.Type>
+    <ApplyCameraProfile.Default Status="Valid" IsReadOnly="true">false</ApplyCameraProfile.Default>
+    <ApplyImageOrientation Status="Valid">true</ApplyImageOrientation>
+    <ApplyImageOrientation.Type Status="Valid" IsReadOnly="true">BoolType</ApplyImageOrientation.Type>
+    <ApplyImageOrientation.Default Status="Valid" IsReadOnly="true">true</ApplyImageOrientation.Default>
+    <CalculateExposureTimeResult Status="Valid" IsReadOnly="true"/>
+    <CalculateExposureTimeResult.Type Status="Valid" IsReadOnly="true">StringType</CalculateExposureTimeResult.Type>
+    <CalculateExposureTimeResult.Default Status="Valid" IsReadOnly="true"/>
+    <CameraBias Status="Valid" IsReadOnly="true">0</CameraBias>
+    <CameraBias.Type Status="Valid" IsReadOnly="true">IntegerType</CameraBias.Type>
+    <CameraBias.Default Status="Valid" IsReadOnly="true">0</CameraBias.Default>
+    <CameraOrientation Status="Valid" IsReadOnly="true">0</CameraOrientation>
+    <CameraOrientation.Type Status="Valid" IsReadOnly="true">IntegerType</CameraOrientation.Type>
+    <CameraOrientation.ListItems Status="Valid" IsReadOnly="true">0|Original|Original,1|Flip|Flip Horizontally,2|Reverse|Flip Vertically,4|Rotate|Rotate 90 CW,7|FlipReverseRotate|Rotate 90 CCW,3|FlipReverse|Rotate 180,6|ReverseRotate|Mirror at +45 Diagonal,5|FlipRotate|Mirror at -45 Diagonal</CameraOrientation.ListItems>
+    <CameraPixelAccuracy Status="Valid" IsReadOnly="true">6.103515625E-05</CameraPixelAccuracy>
+    <CameraPixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</CameraPixelAccuracy.Type>
+    <CameraPixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</CameraPixelAccuracy.Default>
+    <CameraPixelDistances Status="Valid" IsReadOnly="true">3.45,3.45</CameraPixelDistances>
+    <CameraPixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</CameraPixelDistances.Type>
+    <CameraPixelMaximum Status="Valid" IsReadOnly="true">16383</CameraPixelMaximum>
+    <CameraPixelMaximum.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelMaximum.Type>
+    <CameraPixelMaximum.Default Status="Valid" IsReadOnly="true">255</CameraPixelMaximum.Default>
+    <CameraPixelMinimum Status="Valid" IsReadOnly="true">0</CameraPixelMinimum>
+    <CameraPixelMinimum.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelMinimum.Type>
+    <CameraPixelMinimum.Default Status="Valid" IsReadOnly="true">0</CameraPixelMinimum.Default>
+    <CameraPixelType Status="Valid" IsReadOnly="true">Gray8</CameraPixelType>
+    <CameraPixelType.Type Status="Valid" IsReadOnly="true">IntegerType</CameraPixelType.Type>
+    <CameraPixelType.Default Status="Valid" IsReadOnly="true">0</CameraPixelType.Default>
+    <CameraStatus Status="Valid" IsReadOnly="true"/>
+    <CameraStatus.Type Status="Valid" IsReadOnly="true">StringType</CameraStatus.Type>
+    <CameraStatus.Default Status="Valid" IsReadOnly="true"/>
+    <ExposureTime.Type Status="Valid" IsReadOnly="true">DoubleType</ExposureTime.Type>
+    <ExposureTime.Default Status="Valid" IsReadOnly="true">20</ExposureTime.Default>
+    <ExposureTime.Min Status="Valid" IsReadOnly="true">0.1</ExposureTime.Min>
+    <ExposureTime.Max Status="Valid" IsReadOnly="true">600000</ExposureTime.Max>
+    <ExposureTime.Increment Status="Valid" IsReadOnly="true">0.001</ExposureTime.Increment>
+    <ExposureTime.GuiHint Status="Valid" IsReadOnly="true">GuiLogSlider</ExposureTime.GuiHint>
+    <Frame Status="SuperValid">0,0,2464,2056</Frame>
+    <Frame.Type Status="Valid" IsReadOnly="true">RectType</Frame.Type>
+    <Frame.Max Status="Valid" IsReadOnly="true">0,0,2464,2056</Frame.Max>
+    <Frame.GuiHint Status="Valid" IsReadOnly="true">GuiRect</Frame.GuiHint>
+    <ImageByteSize Status="Valid" IsReadOnly="true">5065984</ImageByteSize>
+    <ImageByteSize.Type Status="Valid" IsReadOnly="true">IntegerType</ImageByteSize.Type>
+    <ImageByteSize.Default Status="Valid" IsReadOnly="true">0</ImageByteSize.Default>
+    <ImageFrame Status="Valid" IsReadOnly="true">0,0,2464,2056</ImageFrame>
+    <ImageFrame.Type Status="Valid" IsReadOnly="true">RectType</ImageFrame.Type>
+    <ImageFrame.Max Status="Valid" IsReadOnly="true">0,0,2464,2056</ImageFrame.Max>
+    <ImageOrientation.Type Status="Valid" IsReadOnly="true">IntegerType</ImageOrientation.Type>
+    <ImageOrientation.ListItems Status="Valid" IsReadOnly="true">0|Original|Original,1|Flip|Flip Horizontally,2|Reverse|Flip Vertically,4|Rotate|Rotate 90 CW,7|FlipReverseRotate|Rotate 90 CCW,3|FlipReverse|Rotate 180,6|ReverseRotate|Mirror at +45 Diagonal,5|FlipRotate|Mirror at -45 Diagonal</ImageOrientation.ListItems>
+    <ImageOrientation.Default Status="Valid" IsReadOnly="true">0</ImageOrientation.Default>
+    <ImageOrientation.Label Status="Valid" IsReadOnly="true">Orientation</ImageOrientation.Label>
+    <ImageOrientation.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ImageOrientation.GuiHint>
+    <ImagePixelAccuracy Status="Valid" IsReadOnly="true">0.00390625</ImagePixelAccuracy>
+    <ImagePixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</ImagePixelAccuracy.Type>
+    <ImagePixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</ImagePixelAccuracy.Default>
+    <ImagePixelDistances Status="Valid" IsReadOnly="true">3.45,3.45</ImagePixelDistances>
+    <ImagePixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</ImagePixelDistances.Type>
+    <ImagePixelType Status="Valid" IsReadOnly="true">Gray8</ImagePixelType>
+    <ImagePixelType.Type Status="Valid" IsReadOnly="true">IntegerType</ImagePixelType.Type>
+    <ImagePixelType.Default Status="Valid" IsReadOnly="true">0</ImagePixelType.Default>
+    <LiveFrame Status="Valid" IsReadOnly="true">0,0,2464,2056</LiveFrame>
+    <LiveFrame.Type Status="Valid" IsReadOnly="true">RectType</LiveFrame.Type>
+    <LiveImageByteSize Status="Valid" IsReadOnly="true">5065984</LiveImageByteSize>
+    <LiveImageByteSize.Type Status="Valid" IsReadOnly="true">IntegerType</LiveImageByteSize.Type>
+    <LiveImageByteSize.Default Status="Valid" IsReadOnly="true">0</LiveImageByteSize.Default>
+    <LiveImageFrame Status="Valid" IsReadOnly="true">0,0,2464,2056</LiveImageFrame>
+    <LiveImageFrame.Type Status="Valid" IsReadOnly="true">RectType</LiveImageFrame.Type>
+    <LiveImagePixelAccuracy Status="Valid" IsReadOnly="true">0.00390625</LiveImagePixelAccuracy>
+    <LiveImagePixelAccuracy.Type Status="Valid" IsReadOnly="true">DoubleType</LiveImagePixelAccuracy.Type>
+    <LiveImagePixelAccuracy.Default Status="Valid" IsReadOnly="true">0.00390625</LiveImagePixelAccuracy.Default>
+    <LiveImagePixelDistances Status="Valid" IsReadOnly="true">3.45,3.45</LiveImagePixelDistances>
+    <LiveImagePixelDistances.Type Status="Valid" IsReadOnly="true">SizeType</LiveImagePixelDistances.Type>
+    <LiveImagePixelType Status="Valid" IsReadOnly="true">Gray8</LiveImagePixelType>
+    <LiveImagePixelType.Type Status="Valid" IsReadOnly="true">IntegerType</LiveImagePixelType.Type>
+    <LiveImagePixelType.Default Status="Valid" IsReadOnly="true">0</LiveImagePixelType.Default>
+    <LiveValidBits Status="Valid" IsReadOnly="true">8</LiveValidBits>
+    <LiveValidBits.Type Status="Valid" IsReadOnly="true">IntegerType</LiveValidBits.Type>
+    <LiveValidBits.Default Status="Valid" IsReadOnly="true">8</LiveValidBits.Default>
+    <ValidBits Status="Valid" IsReadOnly="true">8</ValidBits>
+    <ValidBits.Type Status="Valid" IsReadOnly="true">IntegerType</ValidBits.Type>
+    <ValidBits.Default Status="Valid" IsReadOnly="true">8</ValidBits.Default>
+    <ValidPixelMaximum Status="Valid" IsReadOnly="true">16383</ValidPixelMaximum>
+    <ValidPixelMaximum.Type Status="Valid" IsReadOnly="true">IntegerType</ValidPixelMaximum.Type>
+    <ValidPixelMaximum.Default Status="Valid" IsReadOnly="true">255</ValidPixelMaximum.Default>
+    <MultiThreadedAcquisition Status="Valid">false</MultiThreadedAcquisition>
+    <MultiThreadedAcquisition.Type Status="Valid" IsReadOnly="true">BoolType</MultiThreadedAcquisition.Type>
+    <MultiThreadedAcquisition.Default Status="Valid" IsReadOnly="true">false</MultiThreadedAcquisition.Default>
+    <MultiThreadedAcquisition.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</MultiThreadedAcquisition.GuiHint>
+    <MultiThreadedAcquisition.Enabled Status="Valid" IsReadOnly="true">true</MultiThreadedAcquisition.Enabled>
+    <MultiThreadedAcquisition.Mode Status="Valid" IsReadOnly="true">Debug</MultiThreadedAcquisition.Mode>
+    <ContinuousAcquisitionSafeMode Status="Valid">true</ContinuousAcquisitionSafeMode>
+    <ContinuousAcquisitionSafeMode.Type Status="Valid" IsReadOnly="true">BoolType</ContinuousAcquisitionSafeMode.Type>
+    <ContinuousAcquisitionSafeMode.Default Status="Valid" IsReadOnly="true">true</ContinuousAcquisitionSafeMode.Default>
+    <ContinuousAcquisitionSafeMode.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ContinuousAcquisitionSafeMode.GuiHint>
+    <ContinuousAcquisitionSafeMode.Mode Status="Valid" IsReadOnly="true">Debug</ContinuousAcquisitionSafeMode.Mode>
+    <ContinuousAcquisitionSafeMode.Enabled Status="Valid" IsReadOnly="true">true</ContinuousAcquisitionSafeMode.Enabled>
+    <EnableSignalsForFastAcq Status="Valid"/>
+    <EnableSignalsForFastAcq.Type Status="Valid" IsReadOnly="true">BoolType</EnableSignalsForFastAcq.Type>
+    <EnableSignalsForFastAcq.Default Status="Valid" IsReadOnly="true"/>
+    <EnableSignalsForFastAcq.GuiHint Status="Valid" IsReadOnly="true">GuiNone</EnableSignalsForFastAcq.GuiHint>
+    <EnableSignalsForFastAcq.Mode Status="Valid" IsReadOnly="true">Debug</EnableSignalsForFastAcq.Mode>
+    <ShadingReference Status="Valid">false</ShadingReference>
+    <ShadingReference.Type Status="Valid" IsReadOnly="true">BoolType</ShadingReference.Type>
+    <ShadingReference.Default Status="Valid" IsReadOnly="true">false</ShadingReference.Default>
+    <ShadingReference.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ShadingReference.GuiHint>
+    <ShadingReferenceSource Status="Valid">1</ShadingReferenceSource>
+    <ShadingReferenceSource.Type Status="Valid" IsReadOnly="true">IntegerType</ShadingReferenceSource.Type>
+    <ShadingReferenceSource.ListItems Status="Valid" IsReadOnly="true">0|Global|Global,1|Specific|Specific,2|CellDiscoverer|CellDiscoverer</ShadingReferenceSource.ListItems>
+    <ShadingReferenceSource.Default Status="Valid" IsReadOnly="true">1</ShadingReferenceSource.Default>
+    <ShadingReferenceSource.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ShadingReferenceSource.GuiHint>
+    <ShadingReferenceSourceVisibility Status="Valid">true</ShadingReferenceSourceVisibility>
+    <ShadingReferenceSourceVisibility.Type Status="Valid" IsReadOnly="true">BoolType</ShadingReferenceSourceVisibility.Type>
+    <ShadingReferenceSourceVisibility.Default Status="Valid" IsReadOnly="true">true</ShadingReferenceSourceVisibility.Default>
+    <ShadingReferenceSourceVisibility.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ShadingReferenceSourceVisibility.GuiHint>
+    <ShadingReferenceSourceVisibility.Mode Status="Valid" IsReadOnly="true">NoPersist</ShadingReferenceSourceVisibility.Mode>
+    <ShadingReference.Enabled Status="Valid" IsReadOnly="true">false</ShadingReference.Enabled>
+    <Resolution Status="Valid">0</Resolution>
+    <Resolution.Type Status="Valid" IsReadOnly="true">IntegerType</Resolution.Type>
+    <Resolution.ListItems Status="Valid" IsReadOnly="true">0|2464x2056|2464x2056</Resolution.ListItems>
+    <Resolution.Default Status="Valid" IsReadOnly="true">0</Resolution.Default>
+    <Resolution.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</Resolution.GuiHint>
+    <BinningList Status="SuperValid">0</BinningList>
+    <BinningList.Type Status="Valid" IsReadOnly="true">IntegerType</BinningList.Type>
+    <BinningList.ListItems Status="Valid" IsReadOnly="true">0|1x1|1x1,1|2x2|2x2,2|3x3|3x3,3|4x4|4x4,4|5x5|5x5</BinningList.ListItems>
+    <BinningList.Default Status="Valid" IsReadOnly="true">0</BinningList.Default>
+    <BinningList.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</BinningList.GuiHint>
+    <Resolution.Label Status="Valid" IsReadOnly="true">Resolution</Resolution.Label>
+    <ExposureTime.Enabled Status="Valid" IsReadOnly="true">true</ExposureTime.Enabled>
+    <AnalogGainModeList.Type Status="Valid" IsReadOnly="true">IntegerType</AnalogGainModeList.Type>
+    <AnalogGainModeList.ListItems Status="Valid" IsReadOnly="true">0|1x (min)|1x (min),1|2x|2x,2|4x (opt)|4x (opt),3|8x|8x,4|16x (max)|16x (max)</AnalogGainModeList.ListItems>
+    <AnalogGainModeList.Default Status="Valid" IsReadOnly="true">0</AnalogGainModeList.Default>
+    <AnalogGainModeList.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</AnalogGainModeList.GuiHint>
+    <AnalogGainModeList.Enabled Status="Valid" IsReadOnly="true">true</AnalogGainModeList.Enabled>
+    <LiveBinning Status="SuperValid" IsReadOnly="true">1,1</LiveBinning>
+    <LiveBinning.Type Status="Valid" IsReadOnly="true">SizeType</LiveBinning.Type>
+    <LiveBinning.GuiHint Status="Valid" IsReadOnly="true">GuiNone</LiveBinning.GuiHint>
+    <Trigger Status="Valid">false</Trigger>
+    <Trigger.Type Status="Valid" IsReadOnly="true">BoolType</Trigger.Type>
+    <Trigger.Default Status="Valid" IsReadOnly="true">false</Trigger.Default>
+    <Trigger.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</Trigger.GuiHint>
+    <Trigger.Enabled Status="Valid" IsReadOnly="true">true</Trigger.Enabled>
+    <TriggerMode Status="Valid">0</TriggerMode>
+    <TriggerMode.Type Status="Valid" IsReadOnly="true">IntegerType</TriggerMode.Type>
+    <TriggerMode.ListItems Status="Valid" IsReadOnly="true">0|Active High|Active High,1|Active Low|Active Low</TriggerMode.ListItems>
+    <TriggerMode.Default Status="Valid" IsReadOnly="true">0</TriggerMode.Default>
+    <TriggerMode.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</TriggerMode.GuiHint>
+    <TriggerMode.Label Status="Valid" IsReadOnly="true">Acquire|Trigger Mode</TriggerMode.Label>
+    <TriggerMode.Mode Status="Valid" IsReadOnly="true">Expert</TriggerMode.Mode>
+    <TriggerMode.Enabled Status="Valid" IsReadOnly="true">true</TriggerMode.Enabled>
+    <SnapShutter Status="Valid">false</SnapShutter>
+    <SnapShutter.Type Status="Valid" IsReadOnly="true">BoolType</SnapShutter.Type>
+    <SnapShutter.Default Status="Valid" IsReadOnly="true">false</SnapShutter.Default>
+    <SnapShutter.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</SnapShutter.GuiHint>
+    <SnapShutter.Enabled Status="Valid" IsReadOnly="true">true</SnapShutter.Enabled>
+    <LiveShutter Status="Valid">false</LiveShutter>
+    <LiveShutter.Type Status="Valid" IsReadOnly="true">BoolType</LiveShutter.Type>
+    <LiveShutter.Default Status="Valid" IsReadOnly="true">false</LiveShutter.Default>
+    <LiveShutter.Label Status="Valid" IsReadOnly="true">Live Shutter</LiveShutter.Label>
+    <LiveShutter.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</LiveShutter.GuiHint>
+    <LiveShutter.Enabled Status="Valid" IsReadOnly="true">true</LiveShutter.Enabled>
+    <ShutterMode Status="Valid">0</ShutterMode>
+    <ShutterMode.Type Status="Valid" IsReadOnly="true">IntegerType</ShutterMode.Type>
+    <ShutterMode.ListItems Status="Valid" IsReadOnly="true">0|Active High|Active High,1|Active Low|Active Low</ShutterMode.ListItems>
+    <ShutterMode.Default Status="Valid" IsReadOnly="true">0</ShutterMode.Default>
+    <ShutterMode.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ShutterMode.GuiHint>
+    <ShutterMode.Label Status="Valid" IsReadOnly="true">Acquire|Shutter Mode</ShutterMode.Label>
+    <ShutterMode.Mode Status="Valid" IsReadOnly="true">Expert</ShutterMode.Mode>
+    <ShutterMode.Enabled Status="Valid" IsReadOnly="true">true</ShutterMode.Enabled>
+    <ShutterOpenDelay Status="Valid">0</ShutterOpenDelay>
+    <ShutterOpenDelay.Type Status="Valid" IsReadOnly="true">DoubleType</ShutterOpenDelay.Type>
+    <ShutterOpenDelay.Default Status="Valid" IsReadOnly="true">0</ShutterOpenDelay.Default>
+    <ShutterOpenDelay.Min Status="Valid" IsReadOnly="true">-1024</ShutterOpenDelay.Min>
+    <ShutterOpenDelay.Max Status="Valid" IsReadOnly="true">1024</ShutterOpenDelay.Max>
+    <ShutterOpenDelay.Increment Status="Valid" IsReadOnly="true">0.01</ShutterOpenDelay.Increment>
+    <ShutterOpenDelay.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</ShutterOpenDelay.GuiHint>
+    <ShutterOpenDelay.Label Status="Valid" IsReadOnly="true">Acquire|Shutter Open Delay</ShutterOpenDelay.Label>
+    <ShutterOpenDelay.Mode Status="Valid" IsReadOnly="true">Expert</ShutterOpenDelay.Mode>
+    <ShutterOpenDelay.Enabled Status="Valid" IsReadOnly="true">true</ShutterOpenDelay.Enabled>
+    <SoftwareBinningList Status="Valid">0</SoftwareBinningList>
+    <SoftwareBinningList.Type Status="Valid" IsReadOnly="true">IntegerType</SoftwareBinningList.Type>
+    <SoftwareBinningList.ListItems Status="Valid" IsReadOnly="true">0|0|1x1,1|1|2x2,2|2|3x3,3|3|4x4,4|4|5x5</SoftwareBinningList.ListItems>
+    <SoftwareBinningList.Default Status="Valid" IsReadOnly="true">0</SoftwareBinningList.Default>
+    <SoftwareBinningList.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</SoftwareBinningList.GuiHint>
+    <SoftwareBinningList.Label Status="Valid" IsReadOnly="true">Post Processing|SW Subsampling</SoftwareBinningList.Label>
+    <SoftwareBinningList.Enabled Status="Valid" IsReadOnly="true">true</SoftwareBinningList.Enabled>
+    <ResamplingParameterKey Status="Valid">1</ResamplingParameterKey>
+    <ResamplingParameterKey.Type Status="Valid" IsReadOnly="true">DoubleType</ResamplingParameterKey.Type>
+    <ResamplingParameterKey.Default Status="Valid" IsReadOnly="true">1</ResamplingParameterKey.Default>
+    <ResamplingParameterKey.Min Status="Valid" IsReadOnly="true">0.001</ResamplingParameterKey.Min>
+    <ResamplingParameterKey.Max Status="Valid" IsReadOnly="true">500</ResamplingParameterKey.Max>
+    <ResamplingParameterKey.Increment Status="Valid" IsReadOnly="true">1E-06</ResamplingParameterKey.Increment>
+    <ResamplingParameterKey.Label Status="Valid" IsReadOnly="true">Post Processing|Resample</ResamplingParameterKey.Label>
+    <ResamplingParameterKey.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</ResamplingParameterKey.GuiHint>
+    <ResamplingParameterKey.Enabled Status="Valid" IsReadOnly="true">true</ResamplingParameterKey.Enabled>
+    <ResamplingParameterKey.Mode Status="Valid" IsReadOnly="true">Debug</ResamplingParameterKey.Mode>
+    <ResamplingModeParameterKey Status="Valid">0</ResamplingModeParameterKey>
+    <ResamplingModeParameterKey.Type Status="Valid" IsReadOnly="true">IntegerType</ResamplingModeParameterKey.Type>
+    <ResamplingModeParameterKey.Default Status="Valid" IsReadOnly="true">0</ResamplingModeParameterKey.Default>
+    <ResamplingModeParameterKey.Label Status="Valid" IsReadOnly="true">Post Processing|Resample Mode</ResamplingModeParameterKey.Label>
+    <ResamplingModeParameterKey.ListItems Status="Valid" IsReadOnly="true">0|Nearest Neighbour|Nearest Neighbour,1|Linear|Linear</ResamplingModeParameterKey.ListItems>
+    <ResamplingModeParameterKey.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ResamplingModeParameterKey.GuiHint>
+    <ResamplingModeParameterKey.Enabled Status="Valid" IsReadOnly="true">true</ResamplingModeParameterKey.Enabled>
+    <ResamplingModeParameterKey.Mode Status="Valid" IsReadOnly="true">Debug</ResamplingModeParameterKey.Mode>
+    <PixelClock Status="Valid">0</PixelClock>
+    <PixelClock.Type Status="Valid" IsReadOnly="true">IntegerType</PixelClock.Type>
+    <PixelClock.Default Status="Valid" IsReadOnly="true">0</PixelClock.Default>
+    <PixelClock.Label Status="Valid" IsReadOnly="true">Acquire|Readout Speed (MHz)</PixelClock.Label>
+    <PixelClock.ListItems Status="Valid" IsReadOnly="true">0|37|37</PixelClock.ListItems>
+    <PixelClock.GuiHint Status="Valid" IsReadOnly="true">GuiNone</PixelClock.GuiHint>
+    <PixelClock.Enabled Status="Valid" IsReadOnly="true">false</PixelClock.Enabled>
+    <CameraDisplayName.Type Status="Valid" IsReadOnly="true">StringType</CameraDisplayName.Type>
+    <CameraDisplayName.Default Status="Valid" IsReadOnly="true"/>
+    <CameraDisplayName.GuiHint Status="Valid" IsReadOnly="true">GuiNone</CameraDisplayName.GuiHint>
+    <CameraDisplayName.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</CameraDisplayName.Mode>
+    <ImageDeliveryBufferCount Status="Valid">4</ImageDeliveryBufferCount>
+    <ImageDeliveryBufferCount.Type Status="Valid" IsReadOnly="true">IntegerType</ImageDeliveryBufferCount.Type>
+    <ImageDeliveryBufferCount.Default Status="Valid" IsReadOnly="true">4</ImageDeliveryBufferCount.Default>
+    <ImageDeliveryBufferCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ImageDeliveryBufferCount.GuiHint>
+    <CameraExtraControlCommandName Status="Valid"/>
+    <CameraExtraControlCommandName.Type Status="Valid" IsReadOnly="true">StringType</CameraExtraControlCommandName.Type>
+    <CameraExtraControlCommandName.Default Status="Valid" IsReadOnly="true"/>
+    <CameraExtraControlCommandName.Mode Status="Valid" IsReadOnly="true">NoPersist</CameraExtraControlCommandName.Mode>
+    <Adjust.Type Status="Valid" IsReadOnly="true">DoubleType</Adjust.Type>
+    <Adjust.Default Status="Valid" IsReadOnly="true">1</Adjust.Default>
+    <Adjust.Min Status="Valid" IsReadOnly="true">0.05</Adjust.Min>
+    <Adjust.Max Status="Valid" IsReadOnly="true">2</Adjust.Max>
+    <Adjust.Increment Status="Valid" IsReadOnly="true">0.05</Adjust.Increment>
+    <Adjust.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</Adjust.GuiHint>
+    <Adjust.Enabled Status="Valid" IsReadOnly="true">true</Adjust.Enabled>
+    <AdjustFrameRate Status="Valid">true</AdjustFrameRate>
+    <AdjustFrameRate.Type Status="Valid" IsReadOnly="true">BoolType</AdjustFrameRate.Type>
+    <AdjustFrameRate.Default Status="Valid" IsReadOnly="true">true</AdjustFrameRate.Default>
+    <AdjustFrameRate.Label Status="Valid" IsReadOnly="true">Acquire|Adjust Live Frame Rate</AdjustFrameRate.Label>
+    <AdjustFrameRate.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AdjustFrameRate.GuiHint>
+    <AdjustFrameRate.Mode Status="Valid" IsReadOnly="true">Expert</AdjustFrameRate.Mode>
+    <AdjustFrameRate.Enabled Status="Valid" IsReadOnly="true">true</AdjustFrameRate.Enabled>
+    <AdjustFrameRate.DisplayOrder Status="Valid" IsReadOnly="true">201</AdjustFrameRate.DisplayOrder>
+    <AutoExposure Status="Valid">false</AutoExposure>
+    <AutoExposure.Type Status="Valid" IsReadOnly="true">BoolType</AutoExposure.Type>
+    <AutoExposure.Default Status="Valid" IsReadOnly="true">false</AutoExposure.Default>
+    <AutoExposure.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AutoExposure.GuiHint>
+    <AutoExposure.Enabled Status="Valid" IsReadOnly="true">true</AutoExposure.Enabled>
+    <AutoExposureFrame Status="Valid">Empty</AutoExposureFrame>
+    <AutoExposureFrame.Type Status="Valid" IsReadOnly="true">RectType</AutoExposureFrame.Type>
+    <AutoExposureFrame.Default Status="Valid" IsReadOnly="true">Empty</AutoExposureFrame.Default>
+    <AutoExposureFrame.GuiHint Status="Valid" IsReadOnly="true">GuiNone</AutoExposureFrame.GuiHint>
+    <AutoExposureFrame.Enabled Status="Valid" IsReadOnly="true">true</AutoExposureFrame.Enabled>
+    <Binning Status="SuperValid">1,1</Binning>
+    <Binning.Type Status="Valid" IsReadOnly="true">SizeType</Binning.Type>
+    <Binning.Default Status="Valid" IsReadOnly="true">1,1</Binning.Default>
+    <Binning.GuiHint Status="Valid" IsReadOnly="true">GuiNone</Binning.GuiHint>
+    <BlackReference Status="Valid">false</BlackReference>
+    <BlackReference.Type Status="Valid" IsReadOnly="true">BoolType</BlackReference.Type>
+    <BlackReference.Default Status="Valid" IsReadOnly="true">false</BlackReference.Default>
+    <BlackReference.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</BlackReference.GuiHint>
+    <BlackReference.Enabled Status="Valid" IsReadOnly="true">false</BlackReference.Enabled>
+    <DefaultDisplayGamma Status="Valid">1</DefaultDisplayGamma>
+    <DefaultDisplayGamma.Type Status="Valid" IsReadOnly="true">DoubleType</DefaultDisplayGamma.Type>
+    <DefaultDisplayGamma.Default Status="Valid" IsReadOnly="true">1</DefaultDisplayGamma.Default>
+    <DefaultDisplayGamma.Min Status="Valid" IsReadOnly="true">0.3</DefaultDisplayGamma.Min>
+    <DefaultDisplayGamma.Max Status="Valid" IsReadOnly="true">3</DefaultDisplayGamma.Max>
+    <DefaultDisplayGamma.Increment Status="Valid" IsReadOnly="true">0.01</DefaultDisplayGamma.Increment>
+    <DefaultDisplayGamma.Mode Status="Valid" IsReadOnly="true">NoPersist</DefaultDisplayGamma.Mode>
+    <DefaultDisplayGamma.GuiHint Status="Valid" IsReadOnly="true">GuiNone</DefaultDisplayGamma.GuiHint>
+    <DeliverExactFrame Status="Valid">false</DeliverExactFrame>
+    <DeliverExactFrame.Type Status="Valid" IsReadOnly="true">BoolType</DeliverExactFrame.Type>
+    <DeliverExactFrame.Default Status="Valid" IsReadOnly="true">false</DeliverExactFrame.Default>
+    <DeliverExactFrame.Mode Status="Valid" IsReadOnly="true">NoPersist</DeliverExactFrame.Mode>
+    <DeliverExactFrame.GuiHint Status="Valid" IsReadOnly="true">GuiNone</DeliverExactFrame.GuiHint>
+    <DualCameraCalibration Status="Valid">false</DualCameraCalibration>
+    <DualCameraCalibration.Type Status="Valid" IsReadOnly="true">BoolType</DualCameraCalibration.Type>
+    <DualCameraCalibration.Default Status="Valid" IsReadOnly="true">false</DualCameraCalibration.Default>
+    <DualCameraCalibration.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DualCameraCalibration.GuiHint>
+    <DualCameraCalibrationId Status="Valid"/>
+    <DualCameraCalibration.Enabled Status="Valid" IsReadOnly="true">false</DualCameraCalibration.Enabled>
+    <ExposureDelay Status="Valid">0</ExposureDelay>
+    <ExposureDelay.Type Status="Valid" IsReadOnly="true">DoubleType</ExposureDelay.Type>
+    <ExposureDelay.Default Status="Valid" IsReadOnly="true">0</ExposureDelay.Default>
+    <ExposureDelay.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ExposureDelay.GuiHint>
+    <ExposureDelay.Max Status="Valid" IsReadOnly="true">1000</ExposureDelay.Max>
+    <CalculateExposureMaximum Status="Valid">10000</CalculateExposureMaximum>
+    <CalculateExposureMaximum.Type Status="Valid" IsReadOnly="true">DoubleType</CalculateExposureMaximum.Type>
+    <CalculateExposureMaximum.Default Status="Valid" IsReadOnly="true">10000</CalculateExposureMaximum.Default>
+    <CalculateExposureMaximum.Min Status="Valid" IsReadOnly="true">10</CalculateExposureMaximum.Min>
+    <CalculateExposureMaximum.Max Status="Valid" IsReadOnly="true">10000</CalculateExposureMaximum.Max>
+    <CalculateExposureMaximum.Increment Status="Valid" IsReadOnly="true">1</CalculateExposureMaximum.Increment>
+    <CalculateExposureMaximum.Enabled Status="Valid" IsReadOnly="true">true</CalculateExposureMaximum.Enabled>
+    <CalculateExposureMaximum.GuiHint Status="Valid" IsReadOnly="true">GuiNone</CalculateExposureMaximum.GuiHint>
+    <AutoExposureTolerance Status="Valid">0.05</AutoExposureTolerance>
+    <AutoExposureTolerance.Type Status="Valid" IsReadOnly="true">DoubleType</AutoExposureTolerance.Type>
+    <AutoExposureTolerance.Default Status="Valid" IsReadOnly="true">0.05</AutoExposureTolerance.Default>
+    <AutoExposureTolerance.Min Status="Valid" IsReadOnly="true">0</AutoExposureTolerance.Min>
+    <AutoExposureTolerance.Max Status="Valid" IsReadOnly="true">10</AutoExposureTolerance.Max>
+    <AutoExposureTolerance.Increment Status="Valid" IsReadOnly="true">1E-06</AutoExposureTolerance.Increment>
+    <AutoExposureTolerance.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</AutoExposureTolerance.GuiHint>
+    <AutoExposureTolerance.Mode Status="Valid" IsReadOnly="true">Debug</AutoExposureTolerance.Mode>
+    <AutoExposureTolerance.Enabled Status="Valid" IsReadOnly="true">true</AutoExposureTolerance.Enabled>
+    <FrameRate Status="Valid" IsReadOnly="true">11.6</FrameRate>
+    <FrameRate.Type Status="Valid" IsReadOnly="true">DoubleType</FrameRate.Type>
+    <FrameRate.Default Status="Valid" IsReadOnly="true">0</FrameRate.Default>
+    <FrameRate.Label Status="Valid" IsReadOnly="true">Acquire|Live Frame Rate</FrameRate.Label>
+    <FrameRate.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</FrameRate.GuiHint>
+    <FrameRate.Mode Status="Valid" IsReadOnly="true">Expert</FrameRate.Mode>
+    <FrameRate.DisplayOrder Status="Valid" IsReadOnly="true">203</FrameRate.DisplayOrder>
+    <FrameRateTarget.Type Status="Valid" IsReadOnly="true">DoubleType</FrameRateTarget.Type>
+    <FrameRateTarget.Default Status="Valid" IsReadOnly="true">30</FrameRateTarget.Default>
+    <FrameRateTarget.Min Status="Valid" IsReadOnly="true">1</FrameRateTarget.Min>
+    <FrameRateTarget.Max Status="Valid" IsReadOnly="true">100</FrameRateTarget.Max>
+    <FrameRateTarget.Increment Status="Valid" IsReadOnly="true">1</FrameRateTarget.Increment>
+    <FrameRateTarget.Label Status="Valid" IsReadOnly="true">Acquire|Live Frame Rate Max</FrameRateTarget.Label>
+    <FrameRateTarget.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</FrameRateTarget.GuiHint>
+    <FrameRateTarget.Mode Status="Valid" IsReadOnly="true">Expert</FrameRateTarget.Mode>
+    <FrameRateTarget.Enabled Status="Valid" IsReadOnly="true">true</FrameRateTarget.Enabled>
+    <FrameRateTarget.DisplayOrder Status="Valid" IsReadOnly="true">202</FrameRateTarget.DisplayOrder>
+    <HDRBits Status="Valid">2</HDRBits>
+    <HDRBits.Type Status="Valid" IsReadOnly="true">IntegerType</HDRBits.Type>
+    <HDRBits.Default Status="Valid" IsReadOnly="true">2</HDRBits.Default>
+    <HDRBits.Min Status="Valid" IsReadOnly="true">2</HDRBits.Min>
+    <HDRBits.Max Status="Valid" IsReadOnly="true">6</HDRBits.Max>
+    <HDRBits.Increment Status="Valid" IsReadOnly="true">2</HDRBits.Increment>
+    <HDRBits.Mode Status="Valid" IsReadOnly="true">Expert</HDRBits.Mode>
+    <HDRBits.GuiHint Status="Valid" IsReadOnly="true">GuiNone</HDRBits.GuiHint>
+    <ImageOrientation.Enabled Status="Valid" IsReadOnly="true">true</ImageOrientation.Enabled>
+    <NoiseFilter Status="Valid">false</NoiseFilter>
+    <NoiseFilter.Type Status="Valid" IsReadOnly="true">BoolType</NoiseFilter.Type>
+    <NoiseFilter.Default Status="Valid" IsReadOnly="true">false</NoiseFilter.Default>
+    <NoiseFilter.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</NoiseFilter.GuiHint>
+    <NoiseFilterThreshold Status="Valid">1.5</NoiseFilterThreshold>
+    <NoiseFilterThreshold.Type Status="Valid" IsReadOnly="true">DoubleType</NoiseFilterThreshold.Type>
+    <NoiseFilterThreshold.Default Status="Valid" IsReadOnly="true">1.5</NoiseFilterThreshold.Default>
+    <NoiseFilterThreshold.Min Status="Valid" IsReadOnly="true">0</NoiseFilterThreshold.Min>
+    <NoiseFilterThreshold.Max Status="Valid" IsReadOnly="true">10</NoiseFilterThreshold.Max>
+    <NoiseFilterThreshold.Increment Status="Valid" IsReadOnly="true">0.1</NoiseFilterThreshold.Increment>
+    <NoiseFilterThreshold.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</NoiseFilterThreshold.GuiHint>
+    <NoiseFilter.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilter.Enabled>
+    <NoiseFilterThreshold.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilterThreshold.Enabled>
+    <NoiseFilterWithIPP Status="Valid">false</NoiseFilterWithIPP>
+    <NoiseFilterWithIPP.Type Status="Valid" IsReadOnly="true">BoolType</NoiseFilterWithIPP.Type>
+    <NoiseFilterWithIPP.Default Status="Valid" IsReadOnly="true">false</NoiseFilterWithIPP.Default>
+    <NoiseFilterWithIPP.Enabled Status="Valid" IsReadOnly="true">true</NoiseFilterWithIPP.Enabled>
+    <NoiseFilterWithIPP.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</NoiseFilterWithIPP.GuiHint>
+    <NoiseFilterWithIPP.Mode Status="Valid" IsReadOnly="true">Debug</NoiseFilterWithIPP.Mode>
+    <CenteredYFrame Status="Valid">false</CenteredYFrame>
+    <CenteredYFrame.Type Status="Valid" IsReadOnly="true">BoolType</CenteredYFrame.Type>
+    <CenteredYFrame.Default Status="Valid" IsReadOnly="true">false</CenteredYFrame.Default>
+    <CenteredYFrame.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</CenteredYFrame.GuiHint>
+    <CenteredYFrame.Mode Status="Valid" IsReadOnly="true">Debug</CenteredYFrame.Mode>
+    <ReferenceImageCount Status="Valid">3</ReferenceImageCount>
+    <ReferenceImageCount.Type Status="Valid" IsReadOnly="true">IntegerType</ReferenceImageCount.Type>
+    <ReferenceImageCount.Default Status="Valid" IsReadOnly="true">3</ReferenceImageCount.Default>
+    <ReferenceImageCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ReferenceImageCount.GuiHint>
+    <ReferenceImageCount.Label Status="Valid" IsReadOnly="true">Post Processing|Reference Image Count</ReferenceImageCount.Label>
+    <ReferenceImageCount.Enabled Status="Valid" IsReadOnly="true">true</ReferenceImageCount.Enabled>
+    <ReferenceImageCount.Min Status="Valid" IsReadOnly="true">1</ReferenceImageCount.Min>
+    <ReferenceImageCount.Max Status="Valid" IsReadOnly="true">5</ReferenceImageCount.Max>
+    <ReferenceImageCount.Increment Status="Valid" IsReadOnly="true">1</ReferenceImageCount.Increment>
+    <ReferenceImageCount.Mode Status="Valid" IsReadOnly="true">Expert</ReferenceImageCount.Mode>
+    <SnapMode Status="Valid">0</SnapMode>
+    <SnapMode.Type Status="Valid" IsReadOnly="true">IntegerType</SnapMode.Type>
+    <SnapMode.ListItems Status="Valid" IsReadOnly="true">0|Normal|Normal,2|Average|Average,6|Overview|Overview,8|Live|Live,10|Shading|Shading,12|Safe|Safe,3|HDR|HDR</SnapMode.ListItems>
+    <SnapMode.Default Status="Valid" IsReadOnly="true">0</SnapMode.Default>
+    <SnapMode.GuiHint Status="Valid" IsReadOnly="true">GuiNone</SnapMode.GuiHint>
+    <SnapMode.Label Status="Valid" IsReadOnly="true">Acquire|Snap Mode</SnapMode.Label>
+    <SnapMode.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</SnapMode.Mode>
+    <UnsharpMask Status="Valid">false</UnsharpMask>
+    <UnsharpMask.Type Status="Valid" IsReadOnly="true">BoolType</UnsharpMask.Type>
+    <UnsharpMask.Default Status="Valid" IsReadOnly="true">false</UnsharpMask.Default>
+    <UnsharpMask.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</UnsharpMask.GuiHint>
+    <UnsharpMaskState Status="Valid"/>
+    <UnsharpMaskState.Type Status="Valid" IsReadOnly="true">StringType</UnsharpMaskState.Type>
+    <UnsharpMaskState.Default Status="Valid" IsReadOnly="true"/>
+    <UnsharpMask.Enabled Status="Valid" IsReadOnly="true">true</UnsharpMask.Enabled>
+    <ImageCount Status="Valid">3</ImageCount>
+    <ImageCount.Type Status="Valid" IsReadOnly="true">IntegerType</ImageCount.Type>
+    <ImageCount.Default Status="Valid" IsReadOnly="true">3</ImageCount.Default>
+    <ImageCount.Min Status="Valid" IsReadOnly="true">2</ImageCount.Min>
+    <ImageCount.Max Status="Valid" IsReadOnly="true">32</ImageCount.Max>
+    <ImageCount.Increment Status="Valid" IsReadOnly="true">1</ImageCount.Increment>
+    <ImageCount.Mode Status="Valid" IsReadOnly="true">Expert</ImageCount.Mode>
+    <ImageCount.Label Status="Valid" IsReadOnly="true">Acquire|Image Count</ImageCount.Label>
+    <ImageCount.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</ImageCount.GuiHint>
+    <ImageCount.Enabled Status="Valid" IsReadOnly="true">false</ImageCount.Enabled>
+    <ImageCount.DisplayOrder Status="Valid" IsReadOnly="true">302</ImageCount.DisplayOrder>
+    <ImageOrientationWithIPP Status="Valid">true</ImageOrientationWithIPP>
+    <ImageOrientationWithIPP.Type Status="Valid" IsReadOnly="true">BoolType</ImageOrientationWithIPP.Type>
+    <ImageOrientationWithIPP.Default Status="Valid" IsReadOnly="true">true</ImageOrientationWithIPP.Default>
+    <ImageOrientationWithIPP.Enabled Status="Valid" IsReadOnly="true">true</ImageOrientationWithIPP.Enabled>
+    <ImageOrientationWithIPP.Mode Status="Valid" IsReadOnly="true">Debug</ImageOrientationWithIPP.Mode>
+    <ImageOrientationWithIPP.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</ImageOrientationWithIPP.GuiHint>
+    <AcquisitionFrame Status="Valid">0,0,2464,2056</AcquisitionFrame>
+    <AcquisitionFrame.Type Status="Valid" IsReadOnly="true">RectType</AcquisitionFrame.Type>
+    <AcquisitionFrame.Max Status="Valid" IsReadOnly="true">0,0,2464,2056</AcquisitionFrame.Max>
+    <SDKVersion Status="Valid" IsReadOnly="true">2.98</SDKVersion>
+    <SDKVersion.Type Status="Valid" IsReadOnly="true">StringType</SDKVersion.Type>
+    <SDKVersion.Default Status="Valid" IsReadOnly="true">2.98</SDKVersion.Default>
+    <SDKVersion.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</SDKVersion.GuiHint>
+    <SDKVersion.Enabled Status="Valid" IsReadOnly="true">false</SDKVersion.Enabled>
+    <SDKVersion.Mode Status="Valid" IsReadOnly="true">Expert</SDKVersion.Mode>
+    <SDKVersion.Label Status="Valid" IsReadOnly="true">SDK Version</SDKVersion.Label>
+    <AbortOnMissedFrames Status="Valid">true</AbortOnMissedFrames>
+    <AbortOnMissedFrames.Type Status="Valid" IsReadOnly="true">BoolType</AbortOnMissedFrames.Type>
+    <AbortOnMissedFrames.Default Status="Valid" IsReadOnly="true">true</AbortOnMissedFrames.Default>
+    <AbortOnMissedFrames.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AbortOnMissedFrames.GuiHint>
+    <AbortOnMissedFrames.Mode Status="Valid" IsReadOnly="true">Expert</AbortOnMissedFrames.Mode>
+    <AbortOnMissedFrames.Label Status="Valid" IsReadOnly="true">Abort on missed frames</AbortOnMissedFrames.Label>
+    <AbortOnMissedFrames.Enabled Status="Valid" IsReadOnly="true">true</AbortOnMissedFrames.Enabled>
+    <VerifiedFrame Status="SuperValid" IsReadOnly="true">0,0,2464,2056</VerifiedFrame>
+    <VerifiedFrame.Type Status="Valid" IsReadOnly="true">RectType</VerifiedFrame.Type>
+    <VerifiedFrame.Label Status="Valid" IsReadOnly="true">Acquire|Verified Frame</VerifiedFrame.Label>
+    <VerifiedFrame.GuiHint Status="Valid" IsReadOnly="true">GuiNone</VerifiedFrame.GuiHint>
+    <LiveShutterSignal Status="Valid">1</LiveShutterSignal>
+    <LiveShutterSignal.Type Status="Valid" IsReadOnly="true">IntegerType</LiveShutterSignal.Type>
+    <LiveShutterSignal.ListItems Status="Valid" IsReadOnly="true">0|SyncTriggerReady|SyncTriggerReady,1|Exposure|Exposure</LiveShutterSignal.ListItems>
+    <LiveShutterSignal.Default Status="Valid" IsReadOnly="true">1</LiveShutterSignal.Default>
+    <LiveShutterSignal.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</LiveShutterSignal.GuiHint>
+    <LiveShutterSignal.Mode Status="Valid" IsReadOnly="true">Expert</LiveShutterSignal.Mode>
+    <LiveShutterSignal.Label Status="Valid" IsReadOnly="true">Shutter Signal|Live Shutter Signal</LiveShutterSignal.Label>
+    <LiveShutterSignal.Enabled Status="Valid" IsReadOnly="true">true</LiveShutterSignal.Enabled>
+    <ShutterSignal Status="Valid">1</ShutterSignal>
+    <ShutterSignal.Type Status="Valid" IsReadOnly="true">IntegerType</ShutterSignal.Type>
+    <ShutterSignal.ListItems Status="Valid" IsReadOnly="true">0|SyncTriggerReady|SyncTriggerReady,1|Exposure|Exposure</ShutterSignal.ListItems>
+    <ShutterSignal.Default Status="Valid" IsReadOnly="true">1</ShutterSignal.Default>
+    <ShutterSignal.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</ShutterSignal.GuiHint>
+    <ShutterSignal.Mode Status="Valid" IsReadOnly="true">Expert</ShutterSignal.Mode>
+    <ShutterSignal.Label Status="Valid" IsReadOnly="true">Shutter Signal|Shutter Signal</ShutterSignal.Label>
+    <ShutterSignal.Enabled Status="Valid" IsReadOnly="true">true</ShutterSignal.Enabled>
+    <FrameTime Status="Valid">0</FrameTime>
+    <FrameTime.Type Status="Valid" IsReadOnly="true">DoubleType</FrameTime.Type>
+    <FrameTime.Default Status="Valid" IsReadOnly="true">0</FrameTime.Default>
+    <FrameTime.Label Status="Valid" IsReadOnly="true">Acquire|Frame Time</FrameTime.Label>
+    <FrameTime.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</FrameTime.GuiHint>
+    <FrameTime.Enabled Status="Valid" IsReadOnly="true">true</FrameTime.Enabled>
+    <FrameTime.Min Status="Valid" IsReadOnly="true">0</FrameTime.Min>
+    <FrameTime.Max Status="Valid" IsReadOnly="true">5000</FrameTime.Max>
+    <FrameTime.Mode Status="Valid" IsReadOnly="true">Expert</FrameTime.Mode>
+    <ReadoutTime Status="Valid">24.532</ReadoutTime>
+    <ReadoutTime.Type Status="Valid" IsReadOnly="true">DoubleType</ReadoutTime.Type>
+    <ReadoutTime.Default Status="Valid" IsReadOnly="true">0</ReadoutTime.Default>
+    <ReadoutTime.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</ReadoutTime.GuiHint>
+    <ReadoutTime.Enabled Status="Valid" IsReadOnly="true">false</ReadoutTime.Enabled>
+    <ReadoutTime.Mode Status="Valid" IsReadOnly="true">NoPersist</ReadoutTime.Mode>
+    <ReadoutTime.Label Status="Valid" IsReadOnly="true">Acquire|Readout Time</ReadoutTime.Label>
+    <AntiGlow Status="Valid">1</AntiGlow>
+    <AntiGlow.Type Status="Valid" IsReadOnly="true">IntegerType</AntiGlow.Type>
+    <AntiGlow.ListItems Status="Valid" IsReadOnly="true">1|Enabled|Enabled,0|Disabled|Disabled</AntiGlow.ListItems>
+    <AntiGlow.Default Status="Valid" IsReadOnly="true">1</AntiGlow.Default>
+    <AntiGlow.Label Status="Valid" IsReadOnly="true">Acquire|Antiglow - Edge Trigger</AntiGlow.Label>
+    <AntiGlow.Mode Status="Valid" IsReadOnly="true">Expert</AntiGlow.Mode>
+    <AntiGlow.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</AntiGlow.GuiHint>
+    <AntiGlow.Enabled Status="Valid" IsReadOnly="true">true</AntiGlow.Enabled>
+    <PowerStateCurrent Status="Valid" IsReadOnly="true">Active</PowerStateCurrent>
+    <PowerStateCurrent.Type Status="Valid" IsReadOnly="true">StringType</PowerStateCurrent.Type>
+    <PowerStateCurrent.Default Status="Valid" IsReadOnly="true"/>
+    <PowerStateCurrent.Label Status="Valid" IsReadOnly="true">Acquire|Cooling</PowerStateCurrent.Label>
+    <PowerStateCurrent.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</PowerStateCurrent.GuiHint>
+    <PowerStateCurrent.Enabled Status="Valid" IsReadOnly="true">false</PowerStateCurrent.Enabled>
+    <SnapWithSWTrigger Status="Valid">false</SnapWithSWTrigger>
+    <SnapWithSWTrigger.Type Status="Valid" IsReadOnly="true">BoolType</SnapWithSWTrigger.Type>
+    <SnapWithSWTrigger.Default Status="Valid" IsReadOnly="true">false</SnapWithSWTrigger.Default>
+    <SnapWithSWTrigger.Enabled Status="Valid" IsReadOnly="true">true</SnapWithSWTrigger.Enabled>
+    <SnapWithSWTrigger.Mode Status="Valid" IsReadOnly="true">Debug</SnapWithSWTrigger.Mode>
+    <SnapWithSWTrigger.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</SnapWithSWTrigger.GuiHint>
+    <SnapWithSWTrigger.Label Status="Valid" IsReadOnly="true">Snap with SW Trigger</SnapWithSWTrigger.Label>
+    <AxioCamHDR Status="Valid">false</AxioCamHDR>
+    <AxioCamHDR.Type Status="Valid" IsReadOnly="true">BoolType</AxioCamHDR.Type>
+    <AxioCamHDR.Default Status="Valid" IsReadOnly="true">false</AxioCamHDR.Default>
+    <AxioCamHDR.Enabled Status="Valid" IsReadOnly="true">true</AxioCamHDR.Enabled>
+    <AxioCamNativeHDR Status="Valid">false</AxioCamNativeHDR>
+    <AxioCamNativeHDR.Type Status="Valid" IsReadOnly="true">BoolType</AxioCamNativeHDR.Type>
+    <AxioCamNativeHDR.Default Status="Valid" IsReadOnly="true">false</AxioCamNativeHDR.Default>
+    <AxioCamNativeHDR.Mode Status="Valid" IsReadOnly="true">NoPersist</AxioCamNativeHDR.Mode>
+    <AxioCamNativeHDR.GuiHint Status="Valid" IsReadOnly="true">GuiNone</AxioCamNativeHDR.GuiHint>
+    <LineFlickerSuppression Status="Valid">2</LineFlickerSuppression>
+    <LineFlickerSuppression.Type Status="Valid" IsReadOnly="true">IntegerType</LineFlickerSuppression.Type>
+    <LineFlickerSuppression.ListItems Status="Valid" IsReadOnly="true">0|Off|Off,2|Bilinear|Bilinear</LineFlickerSuppression.ListItems>
+    <LineFlickerSuppression.Default Status="Valid" IsReadOnly="true">2</LineFlickerSuppression.Default>
+    <LineFlickerSuppression.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</LineFlickerSuppression.GuiHint>
+    <LineFlickerSuppression.Enabled Status="Valid" IsReadOnly="true">true</LineFlickerSuppression.Enabled>
+    <LineFlickerSuppression.Mode Status="Valid" IsReadOnly="true">Expert</LineFlickerSuppression.Mode>
+    <LineFlickerSuppression.Label Status="Valid" IsReadOnly="true">Line Flicker Suppression</LineFlickerSuppression.Label>
+    <BlemishFiltering Status="Valid">true</BlemishFiltering>
+    <BlemishFiltering.Type Status="Valid" IsReadOnly="true">BoolType</BlemishFiltering.Type>
+    <BlemishFiltering.Default Status="Valid" IsReadOnly="true">true</BlemishFiltering.Default>
+    <BlemishFiltering.Enabled Status="Valid" IsReadOnly="true">true</BlemishFiltering.Enabled>
+    <BlemishFiltering.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</BlemishFiltering.GuiHint>
+    <BlemishFiltering.Mode Status="Valid" IsReadOnly="true">Expert</BlemishFiltering.Mode>
+    <BlemishFiltering.Label Status="Valid" IsReadOnly="true">Blemish Filtering</BlemishFiltering.Label>
+    <HighImageRateMode Status="Valid">true</HighImageRateMode>
+    <HighImageRateMode.Type Status="Valid" IsReadOnly="true">BoolType</HighImageRateMode.Type>
+    <HighImageRateMode.Default Status="Valid" IsReadOnly="true">true</HighImageRateMode.Default>
+    <HighImageRateMode.Enabled Status="Valid" IsReadOnly="true">true</HighImageRateMode.Enabled>
+    <HighImageRateMode.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</HighImageRateMode.GuiHint>
+    <HighImageRateMode.Mode Status="Valid" IsReadOnly="true">Expert</HighImageRateMode.Mode>
+    <HighImageRateMode.Label Status="Valid" IsReadOnly="true">High Image Rate Mode</HighImageRateMode.Label>
+    <CameraSubsampling Status="Valid">0</CameraSubsampling>
+    <CameraSubsampling.Type Status="Valid" IsReadOnly="true">IntegerType</CameraSubsampling.Type>
+    <CameraSubsampling.ListItems Status="Valid" IsReadOnly="true">0|1x1|1x1,1|2x2|2x2</CameraSubsampling.ListItems>
+    <CameraSubsampling.Default Status="Valid" IsReadOnly="true">0</CameraSubsampling.Default>
+    <CameraSubsampling.Enabled Status="Valid" IsReadOnly="true">true</CameraSubsampling.Enabled>
+    <CameraBitsPerPixel Status="Valid">2</CameraBitsPerPixel>
+    <CameraBitsPerPixel.Type Status="Valid" IsReadOnly="true">IntegerType</CameraBitsPerPixel.Type>
+    <CameraBitsPerPixel.ListItems Status="Valid" IsReadOnly="true">0|14|14,1|12|12,2|8|8</CameraBitsPerPixel.ListItems>
+    <CameraBitsPerPixel.Default Status="Valid" IsReadOnly="true">0</CameraBitsPerPixel.Default>
+    <CameraBitsPerPixel.Enabled Status="Valid" IsReadOnly="true">true</CameraBitsPerPixel.Enabled>
+    <CameraLUT1 Status="Valid">0</CameraLUT1>
+    <CameraLUT1.Type Status="Valid" IsReadOnly="true">DoubleType</CameraLUT1.Type>
+    <CameraLUT1.Default Status="Valid" IsReadOnly="true">0</CameraLUT1.Default>
+    <CameraLUT1.Min Status="Valid" IsReadOnly="true">0</CameraLUT1.Min>
+    <CameraLUT1.Max Status="Valid" IsReadOnly="true">1</CameraLUT1.Max>
+    <CameraLUT1.Increment Status="Valid" IsReadOnly="true">0.01</CameraLUT1.Increment>
+    <CameraLUT1.Enabled Status="Valid" IsReadOnly="true">true</CameraLUT1.Enabled>
+    <CameraLUT2 Status="Valid">1</CameraLUT2>
+    <CameraLUT2.Type Status="Valid" IsReadOnly="true">DoubleType</CameraLUT2.Type>
+    <CameraLUT2.Default Status="Valid" IsReadOnly="true">1</CameraLUT2.Default>
+    <CameraLUT2.Min Status="Valid" IsReadOnly="true">0</CameraLUT2.Min>
+    <CameraLUT2.Max Status="Valid" IsReadOnly="true">1</CameraLUT2.Max>
+    <CameraLUT2.Increment Status="Valid" IsReadOnly="true">0.01</CameraLUT2.Increment>
+    <CameraLUT2.Enabled Status="Valid" IsReadOnly="true">true</CameraLUT2.Enabled>
+    <CameraGamma Status="Valid">1</CameraGamma>
+    <CameraGamma.Type Status="Valid" IsReadOnly="true">DoubleType</CameraGamma.Type>
+    <CameraGamma.Default Status="Valid" IsReadOnly="true">1</CameraGamma.Default>
+    <CameraGamma.Min Status="Valid" IsReadOnly="true">0.25</CameraGamma.Min>
+    <CameraGamma.Max Status="Valid" IsReadOnly="true">4</CameraGamma.Max>
+    <CameraGamma.Increment Status="Valid" IsReadOnly="true">0.01</CameraGamma.Increment>
+    <CameraGamma.Enabled Status="Valid" IsReadOnly="true">true</CameraGamma.Enabled>
+    <Temperature.Type Status="Valid" IsReadOnly="true">DoubleType</Temperature.Type>
+    <Temperature.Default Status="Valid" IsReadOnly="true">-20</Temperature.Default>
+    <Temperature.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</Temperature.GuiHint>
+    <Temperature.Label Status="Valid" IsReadOnly="true">Temperature|Temperature</Temperature.Label>
+    <Temperature.Enabled Status="Valid" IsReadOnly="true">false</Temperature.Enabled>
+    <TemperatureState Status="Valid" IsReadOnly="true">Stable</TemperatureState>
+    <TemperatureState.Type Status="Valid" IsReadOnly="true">IntegerType</TemperatureState.Type>
+    <TemperatureState.ListItems Status="Valid" IsReadOnly="true">0|Stable|Stable,1|Unstable|Unstable,2|Cooling|Cooling,3|Heating|Heating</TemperatureState.ListItems>
+    <TemperatureState.Default Status="Valid" IsReadOnly="true">1</TemperatureState.Default>
+    <TemperatureState.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</TemperatureState.GuiHint>
+    <TemperatureState.Label Status="Valid" IsReadOnly="true">Temperature|Temperature State</TemperatureState.Label>
+    <TemperatureState.Enabled Status="Valid" IsReadOnly="true">true</TemperatureState.Enabled>
+    <TargetTemperature Status="Valid">18</TargetTemperature>
+    <TargetTemperature.Type Status="Valid" IsReadOnly="true">DoubleType</TargetTemperature.Type>
+    <TargetTemperature.Default Status="Valid" IsReadOnly="true">18</TargetTemperature.Default>
+    <TargetTemperature.Min Status="Valid" IsReadOnly="true">18</TargetTemperature.Min>
+    <TargetTemperature.Max Status="Valid" IsReadOnly="true">50</TargetTemperature.Max>
+    <TargetTemperature.Increment Status="Valid" IsReadOnly="true">1</TargetTemperature.Increment>
+    <TargetTemperature.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</TargetTemperature.GuiHint>
+    <TargetTemperature.Label Status="Valid" IsReadOnly="true">Temperature|Target Temperature</TargetTemperature.Label>
+    <TargetTemperature.Enabled Status="Valid" IsReadOnly="true">true</TargetTemperature.Enabled>
+    <TargetTemperature.Mode Status="Valid" IsReadOnly="true">Expert</TargetTemperature.Mode>
+    <CoolingPowerInfo.Type Status="Valid" IsReadOnly="true">StringType</CoolingPowerInfo.Type>
+    <CoolingPowerInfo.Default Status="Valid" IsReadOnly="true"/>
+    <CoolingPowerInfo.Label Status="Valid" IsReadOnly="true">Temperature|Cooling Power</CoolingPowerInfo.Label>
+    <CoolingPowerInfo.Enabled Status="Valid" IsReadOnly="true">true</CoolingPowerInfo.Enabled>
+    <CoolingPowerInfo.Mode Status="Valid" IsReadOnly="true">Expert</CoolingPowerInfo.Mode>
+    <CoolingPowerInfo.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</CoolingPowerInfo.GuiHint>
+    <PreProcessingMemoryBuffersCount Status="Valid">0</PreProcessingMemoryBuffersCount>
+    <PreProcessingMemoryBuffersCount.Type Status="Valid" IsReadOnly="true">IntegerType</PreProcessingMemoryBuffersCount.Type>
+    <PreProcessingMemoryBuffersCount.Default Status="Valid" IsReadOnly="true">0</PreProcessingMemoryBuffersCount.Default>
+    <PreProcessingMemoryBuffersCount.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</PreProcessingMemoryBuffersCount.GuiHint>
+    <PreProcessingMemoryBuffersCount.Enabled Status="Valid" IsReadOnly="true">true</PreProcessingMemoryBuffersCount.Enabled>
+    <PreProcessingMemoryBuffersCount.Min Status="Valid" IsReadOnly="true">0</PreProcessingMemoryBuffersCount.Min>
+    <PreProcessingMemoryBuffersCount.Max Status="Valid" IsReadOnly="true">10000</PreProcessingMemoryBuffersCount.Max>
+    <PreProcessingMemoryBuffersCount.Mode Status="Valid" IsReadOnly="true">Debug</PreProcessingMemoryBuffersCount.Mode>
+    <PreProcessingDiscBuffersCount Status="Valid">0</PreProcessingDiscBuffersCount>
+    <PreProcessingDiscBuffersCount.Type Status="Valid" IsReadOnly="true">IntegerType</PreProcessingDiscBuffersCount.Type>
+    <PreProcessingDiscBuffersCount.Default Status="Valid" IsReadOnly="true">0</PreProcessingDiscBuffersCount.Default>
+    <PreProcessingDiscBuffersCount.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</PreProcessingDiscBuffersCount.GuiHint>
+    <PreProcessingDiscBuffersCount.Enabled Status="Valid" IsReadOnly="true">true</PreProcessingDiscBuffersCount.Enabled>
+    <PreProcessingDiscBuffersCount.Min Status="Valid" IsReadOnly="true">0</PreProcessingDiscBuffersCount.Min>
+    <PreProcessingDiscBuffersCount.Max Status="Valid" IsReadOnly="true">10000</PreProcessingDiscBuffersCount.Max>
+    <PreProcessingDiscBuffersCount.Mode Status="Valid" IsReadOnly="true">Debug</PreProcessingDiscBuffersCount.Mode>
+    <DiscMemoryType Status="Valid">false</DiscMemoryType>
+    <DiscMemoryType.Type Status="Valid" IsReadOnly="true">BoolType</DiscMemoryType.Type>
+    <DiscMemoryType.Default Status="Valid" IsReadOnly="true">false</DiscMemoryType.Default>
+    <DiscMemoryType.Enabled Status="Valid" IsReadOnly="true">true</DiscMemoryType.Enabled>
+    <DiscMemoryType.Mode Status="Valid" IsReadOnly="true">Debug</DiscMemoryType.Mode>
+    <DiscMemoryType.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</DiscMemoryType.GuiHint>
+    <ApplyParametersCommand Status="Valid"/>
+    <ApplyParametersCommand.Type Status="Valid" IsReadOnly="true">StringType</ApplyParametersCommand.Type>
+    <ApplyParametersCommand.Default Status="Valid" IsReadOnly="true"/>
+    <ApplyParametersCommand.Enabled Status="Valid" IsReadOnly="true">true</ApplyParametersCommand.Enabled>
+    <ApplyParametersCommand.Label Status="Valid" IsReadOnly="true">Apply</ApplyParametersCommand.Label>
+    <ApplyParametersCommand.GuiHint Status="Valid" IsReadOnly="true">GuiButton</ApplyParametersCommand.GuiHint>
+    <ApplyParametersCommand.Mode Status="Valid" IsReadOnly="true">Debug, NoPersist</ApplyParametersCommand.Mode>
+    <ResetDecoderCache Status="Valid"/>
+    <ResetDecoderCache.Type Status="Valid" IsReadOnly="true">StringType</ResetDecoderCache.Type>
+    <ResetDecoderCache.Default Status="Valid" IsReadOnly="true"/>
+    <ResetDecoderCache.Enabled Status="Valid" IsReadOnly="true">true</ResetDecoderCache.Enabled>
+    <ResetDecoderCache.Label Status="Valid" IsReadOnly="true">Reset Decoder</ResetDecoderCache.Label>
+    <ResetDecoderCache.GuiHint Status="Valid" IsReadOnly="true">GuiButton</ResetDecoderCache.GuiHint>
+    <ResetDecoderCache.Mode Status="Valid" IsReadOnly="true">Debug, NoPersist</ResetDecoderCache.Mode>
+    <CacheDecoder Status="Valid">false</CacheDecoder>
+    <CacheDecoder.Type Status="Valid" IsReadOnly="true">BoolType</CacheDecoder.Type>
+    <CacheDecoder.Default Status="Valid" IsReadOnly="true">false</CacheDecoder.Default>
+    <CacheDecoder.Enabled Status="Valid" IsReadOnly="true">true</CacheDecoder.Enabled>
+    <CacheDecoder.Label Status="Valid" IsReadOnly="true">Cache Decoder</CacheDecoder.Label>
+    <CacheDecoder.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</CacheDecoder.GuiHint>
+    <CacheDecoder.Mode Status="Valid" IsReadOnly="true">Debug, NoPersist</CacheDecoder.Mode>
+    <AutoCompression Status="Valid">0</AutoCompression>
+    <AutoCompression.Type Status="Valid" IsReadOnly="true">IntegerType</AutoCompression.Type>
+    <AutoCompression.Default Status="Valid" IsReadOnly="true">0</AutoCompression.Default>
+    <AutoCompression.Label Status="Valid" IsReadOnly="true">Acquire|Bandwidth Management</AutoCompression.Label>
+    <AutoCompression.GuiHint Status="Valid" IsReadOnly="true">GuiComboBox</AutoCompression.GuiHint>
+    <AutoCompression.Enabled Status="Valid" IsReadOnly="true">true</AutoCompression.Enabled>
+    <AutoCompression.ListItems Status="Valid" IsReadOnly="true">0|Auto|Auto,1|On|On,2|Off|Off</AutoCompression.ListItems>
+    <AutoCompression.Mode Status="Valid" IsReadOnly="true">Expert</AutoCompression.Mode>
+    <ContinuousAcquisitionMode Status="Valid">0</ContinuousAcquisitionMode>
+    <ContinuousAcquisitionMode.Type Status="Valid" IsReadOnly="true">IntegerType</ContinuousAcquisitionMode.Type>
+    <ContinuousAcquisitionMode.ListItems Status="Valid" IsReadOnly="true">0|Normal|Normal,1|Burst|Burst,2|LineScan|LineScan,4|MultiSnap|MultiSnap</ContinuousAcquisitionMode.ListItems>
+    <ContinuousAcquisitionMode.Default Status="Valid" IsReadOnly="true">0</ContinuousAcquisitionMode.Default>
+    <SequenceCount Status="Valid">0</SequenceCount>
+    <SequenceCount.GuiHint Status="Valid" IsReadOnly="true">GuiNone</SequenceCount.GuiHint>
+    <SequenceCount.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</SequenceCount.Mode>
+    <SequenceProgress Status="Valid">true</SequenceProgress>
+    <SequenceProgress.Type Status="Valid" IsReadOnly="true">BoolType</SequenceProgress.Type>
+    <SequenceProgress.Default Status="Valid" IsReadOnly="true">true</SequenceProgress.Default>
+    <SequenceProgress.GuiHint Status="Valid" IsReadOnly="true">GuiNone</SequenceProgress.GuiHint>
+    <ContinuousAcquisitionMode.GuiHint Status="Valid" IsReadOnly="true">GuiNone</ContinuousAcquisitionMode.GuiHint>
+    <ContinuousAcquisitionMode.Mode Status="Valid" IsReadOnly="true">NoPersist</ContinuousAcquisitionMode.Mode>
+    <LEDIntensity Status="Valid">9</LEDIntensity>
+    <LEDIntensity.Type Status="Valid" IsReadOnly="true">IntegerType</LEDIntensity.Type>
+    <LEDIntensity.Default Status="Valid" IsReadOnly="true">9</LEDIntensity.Default>
+    <LEDIntensity.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</LEDIntensity.GuiHint>
+    <LEDIntensity.Enabled Status="Valid" IsReadOnly="true">true</LEDIntensity.Enabled>
+    <LEDIntensity.Label Status="Valid" IsReadOnly="true">Main LED</LEDIntensity.Label>
+    <LEDIntensity.Min Status="Valid" IsReadOnly="true">0</LEDIntensity.Min>
+    <LEDIntensity.Max Status="Valid" IsReadOnly="true">9</LEDIntensity.Max>
+    <LEDIntensity.Mode Status="Valid" IsReadOnly="true">Expert</LEDIntensity.Mode>
+    <USBChannelState1 Status="Valid" IsReadOnly="true">SuperSpeed - Data</USBChannelState1>
+    <USBChannelState1.Type Status="Valid" IsReadOnly="true">StringType</USBChannelState1.Type>
+    <USBChannelState1.Default Status="Valid" IsReadOnly="true"/>
+    <USBChannelState1.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</USBChannelState1.GuiHint>
+    <USBChannelState1.Enabled Status="Valid" IsReadOnly="true">false</USBChannelState1.Enabled>
+    <USBChannelState1.Label Status="Valid" IsReadOnly="true">USB Channel 1</USBChannelState1.Label>
+    <USBChannelState1.Mode Status="Valid" IsReadOnly="true">Expert</USBChannelState1.Mode>
+    <USBChannelState2 Status="Valid" IsReadOnly="true">HighSpeed</USBChannelState2>
+    <USBChannelState2.Type Status="Valid" IsReadOnly="true">StringType</USBChannelState2.Type>
+    <USBChannelState2.Default Status="Valid" IsReadOnly="true"/>
+    <USBChannelState2.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</USBChannelState2.GuiHint>
+    <USBChannelState2.Enabled Status="Valid" IsReadOnly="true">false</USBChannelState2.Enabled>
+    <USBChannelState2.Label Status="Valid" IsReadOnly="true">USB Channel 2</USBChannelState2.Label>
+    <USBChannelState2.Mode Status="Valid" IsReadOnly="true">Expert</USBChannelState2.Mode>
+    <USBConnectionColorIndicator Status="Valid" IsReadOnly="true">0 0 255</USBConnectionColorIndicator>
+    <USBConnectionColorIndicator.Type Status="Valid" IsReadOnly="true">StringType</USBConnectionColorIndicator.Type>
+    <USBConnectionColorIndicator.Default Status="Valid" IsReadOnly="true"/>
+    <USBConnectionColorIndicator.GuiHint Status="Valid" IsReadOnly="true">GuiColorIndicator</USBConnectionColorIndicator.GuiHint>
+    <USBConnectionColorIndicator.Enabled Status="Valid" IsReadOnly="true">true</USBConnectionColorIndicator.Enabled>
+    <USBConnectionColorIndicator.Mode Status="Valid" IsReadOnly="true">NoPersist</USBConnectionColorIndicator.Mode>
+    <USBConnectionColorIndicator.Label Status="Valid" IsReadOnly="true">Acquire|USB Status - Camera LED</USBConnectionColorIndicator.Label>
+    <LEDIntensityTrigger Status="Valid">9</LEDIntensityTrigger>
+    <LEDIntensityTrigger.Type Status="Valid" IsReadOnly="true">IntegerType</LEDIntensityTrigger.Type>
+    <LEDIntensityTrigger.Default Status="Valid" IsReadOnly="true">9</LEDIntensityTrigger.Default>
+    <LEDIntensityTrigger.GuiHint Status="Valid" IsReadOnly="true">GuiSlider</LEDIntensityTrigger.GuiHint>
+    <LEDIntensityTrigger.Enabled Status="Valid" IsReadOnly="true">true</LEDIntensityTrigger.Enabled>
+    <LEDIntensityTrigger.Label Status="Valid" IsReadOnly="true">Trigger LED</LEDIntensityTrigger.Label>
+    <LEDIntensityTrigger.Min Status="Valid" IsReadOnly="true">0</LEDIntensityTrigger.Min>
+    <LEDIntensityTrigger.Max Status="Valid" IsReadOnly="true">9</LEDIntensityTrigger.Max>
+    <LEDIntensityTrigger.Mode Status="Valid" IsReadOnly="true">Expert</LEDIntensityTrigger.Mode>
+    <CameraIdentifier Status="Valid" IsReadOnly="true">Axiocam705m_S843</CameraIdentifier>
+    <CameraIdentifier.Type Status="Valid" IsReadOnly="true">StringType</CameraIdentifier.Type>
+    <CameraIdentifier.Default Status="Valid" IsReadOnly="true"/>
+    <CameraIdentifier.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</CameraIdentifier.GuiHint>
+    <CameraIdentifier.DisplayOrder Status="Valid" IsReadOnly="true">-999</CameraIdentifier.DisplayOrder>
+    <CameraIdentifier.Label Status="Valid" IsReadOnly="true">Camera Identifier</CameraIdentifier.Label>
+    <AutomaticTriggerControl Status="Valid">true</AutomaticTriggerControl>
+    <AutomaticTriggerControl.Type Status="Valid" IsReadOnly="true">BoolType</AutomaticTriggerControl.Type>
+    <AutomaticTriggerControl.Default Status="Valid" IsReadOnly="true">true</AutomaticTriggerControl.Default>
+    <AutomaticTriggerControl.Enabled Status="Valid" IsReadOnly="true">true</AutomaticTriggerControl.Enabled>
+    <AutomaticTriggerControl.Label Status="Valid" IsReadOnly="true">Acquire|Auto Trigger Control</AutomaticTriggerControl.Label>
+    <AutomaticTriggerControl.Mode Status="Valid" IsReadOnly="true">Expert, NoPersist</AutomaticTriggerControl.Mode>
+    <AutomaticTriggerControl.GuiHint Status="Valid" IsReadOnly="true">GuiNone</AutomaticTriggerControl.GuiHint>
+    <SuppressTemperatureWarnings Status="Valid">false</SuppressTemperatureWarnings>
+    <SuppressTemperatureWarnings.Type Status="Valid" IsReadOnly="true">BoolType</SuppressTemperatureWarnings.Type>
+    <SuppressTemperatureWarnings.Default Status="Valid" IsReadOnly="true">false</SuppressTemperatureWarnings.Default>
+    <SuppressTemperatureWarnings.Mode Status="Valid" IsReadOnly="true">NoPersist</SuppressTemperatureWarnings.Mode>
+    <Resolution.Enabled Status="Valid" IsReadOnly="true">false</Resolution.Enabled>
+    <BinningList.Enabled Status="Valid" IsReadOnly="true">true</BinningList.Enabled>
+    <Frame.Enabled Status="Valid" IsReadOnly="true">true</Frame.Enabled>
+    <LiveImageFrame.Max Status="Valid" IsReadOnly="true">0,0,2464,2056</LiveImageFrame.Max>
+    <HDRBits.Enabled Status="Valid" IsReadOnly="true">false</HDRBits.Enabled>
+    <SequenceCount.Enabled Status="Valid" IsReadOnly="true">false</SequenceCount.Enabled>
+    <BinningExposureDependency Status="Valid" IsReadOnly="true">2</BinningExposureDependency>
+    <BinningExposureDependency.Type Status="Valid" IsReadOnly="true">IntegerType</BinningExposureDependency.Type>
+    <BinningExposureDependency.Default Status="Valid" IsReadOnly="true">2</BinningExposureDependency.Default>
+    <BinningExposureDependency.Label Status="Valid" IsReadOnly="true">Binning Exposure Dependency</BinningExposureDependency.Label>
+    <BinningExposureDependency.GuiHint Status="Valid" IsReadOnly="true">GuiTextBox</BinningExposureDependency.GuiHint>
+    <BinningExposureDependency.Mode Status="Valid" IsReadOnly="true">Debug, NoPersist</BinningExposureDependency.Mode>
+    <AdaptExposureByBinningChange Status="Valid">false</AdaptExposureByBinningChange>
+    <AdaptExposureByBinningChange.Type Status="Valid" IsReadOnly="true">BoolType</AdaptExposureByBinningChange.Type>
+    <AdaptExposureByBinningChange.Default Status="Valid" IsReadOnly="true">false</AdaptExposureByBinningChange.Default>
+    <AdaptExposureByBinningChange.GuiHint Status="Valid" IsReadOnly="true">GuiCheckBox</AdaptExposureByBinningChange.GuiHint>
+    <AdaptExposureByBinningChange.Label Status="Valid" IsReadOnly="true">Binning-independent Brightness</AdaptExposureByBinningChange.Label>
+    <AdaptExposureByBinningChange.Enabled Status="Valid" IsReadOnly="true">true</AdaptExposureByBinningChange.Enabled>
+    <TheoreticalTotalMagnification Status="Valid" IsActivated="true" IsReadOnly="true">63</TheoreticalTotalMagnification>
+    <TotalMagnification Status="Valid" IsActivated="true" IsReadOnly="true">65.06075</TotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsActivated="true" IsReadOnly="true">µm</DefaultScalingUnit>
+    <RoiCenterOffsetX Status="Valid" IsActivated="true" IsReadOnly="true">0</RoiCenterOffsetX>
+    <RoiCenterOffsetY Status="Valid" IsActivated="true" IsReadOnly="true">0</RoiCenterOffsetY>
+    <TotalAperture Status="Valid" IsActivated="true" IsReadOnly="true">1.4</TotalAperture>
+    <ShadingReferenceSource.Type.Readonly Status="Valid">true</ShadingReferenceSource.Type.Readonly>
+    <ShadingReferenceSource.ListItems.Readonly Status="Valid">true</ShadingReferenceSource.ListItems.Readonly>
+    <ShadingReferenceSource.Default.Readonly Status="Valid">true</ShadingReferenceSource.Default.Readonly>
+    <ShadingReferenceSource.GuiHint.Readonly Status="Valid">true</ShadingReferenceSource.GuiHint.Readonly>
+    <DeliverExactFrame.Type.Readonly Status="Valid">true</DeliverExactFrame.Type.Readonly>
+    <DeliverExactFrame.Default.Readonly Status="Valid">true</DeliverExactFrame.Default.Readonly>
+    <DeliverExactFrame.Mode.Readonly Status="Valid">true</DeliverExactFrame.Mode.Readonly>
+    <DeliverExactFrame.GuiHint.Readonly Status="Valid">true</DeliverExactFrame.GuiHint.Readonly>
+    <SequenceCount.GuiHint.Readonly Status="Valid">true</SequenceCount.GuiHint.Readonly>
+    <SequenceCount.Mode.Readonly Status="Valid">true</SequenceCount.Mode.Readonly>
+    <SequenceCount.Enabled.Readonly Status="Valid">true</SequenceCount.Enabled.Readonly>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Laser561WarmupProgress">
+    <Position Status="Valid">100</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Laser561">
+    <LaserEnableTime Status="Valid" IsReadOnly="true">1609800</LaserEnableTime>
+    <IsEnabled Status="Valid">true</IsEnabled>
+    <IsWarmingUp Status="Valid" IsReadOnly="true">false</IsWarmingUp>
+    <Wavelength Status="Valid">0</Wavelength>
+    <LaserStatus Status="Valid" IsReadOnly="true">Ready</LaserStatus>
+    <WarmUpProgress Status="Valid" IsReadOnly="true" Minimum="0" Maximum="100">38</WarmUpProgress>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLEDArraySF_TL">
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <Intensity Status="Valid">18.181818181818</Intensity>
+    <LEDArrayContrastTypeBitmask Status="Valid">SLISD</LEDArrayContrastTypeBitmask>
+    <LEDArrayContrastType Status="Valid">CentralLed</LEDArrayContrastType>
+    <SelectedLED Status="Valid">0</SelectedLED>
+    <SelectedSubPattern Status="Valid">0</SelectedSubPattern>
+    <SubPatternCount Status="Valid">0</SubPatternCount>
+    <ProcessingMode Status="Valid">Minimum</ProcessingMode>
+    <IsSwitchedOn/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCondenserRLTempSensor">
+    <Position Status="Valid">24.875</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSMImagingDevice">
+    <TotalAperture Status="Valid" IsReadOnly="true">1.4</TotalAperture>
+    <TotalMagnification Status="Valid" IsReadOnly="true">63</TotalMagnification>
+    <TheoreticalTotalMagnification Status="Valid" IsReadOnly="true">63</TheoreticalTotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsReadOnly="true">µm</DefaultScalingUnit>
+    <OpticalSystemParametersChanged Status="Valid" IsReadOnly="true">3</OpticalSystemParametersChanged>
+    <ImageByteSize Status="Valid" IsReadOnly="true">262144</ImageByteSize>
+    <SizeXMin Status="Valid" IsReadOnly="true">1</SizeXMin>
+    <SizeXMax Status="Valid" IsReadOnly="true">8192</SizeXMax>
+    <SizeYMin Status="Valid" IsReadOnly="true">1</SizeYMin>
+    <SizeYMax Status="Valid" IsReadOnly="true">8192</SizeYMax>
+    <OffsetXMin Status="Valid" IsReadOnly="true">-256</OffsetXMin>
+    <OffsetYMin Status="Valid" IsReadOnly="true">-256</OffsetYMin>
+    <OffsetXMax Status="Valid" IsReadOnly="true">256</OffsetXMax>
+    <OffsetYMax Status="Valid" IsReadOnly="true">256</OffsetYMax>
+    <ScanSpeedMin Status="Valid" IsReadOnly="true">1</ScanSpeedMin>
+    <ScanSpeedMax Status="Valid" IsReadOnly="true">9</ScanSpeedMax>
+    <RoiCenterOffsetXMin Status="Valid" IsReadOnly="true">-67.343650793651</RoiCenterOffsetXMin>
+    <RoiCenterOffsetXMax Status="Valid" IsReadOnly="true">67.343650793651</RoiCenterOffsetXMax>
+    <RoiCenterOffsetYMin Status="Valid" IsReadOnly="true">-67.343650793651</RoiCenterOffsetYMin>
+    <RoiCenterOffsetYMax Status="Valid" IsReadOnly="true">67.343650793651</RoiCenterOffsetYMax>
+    <SplineSupportPoints Status="Valid"/>
+    <SplineViolations Status="Valid" IsReadOnly="true">
+     <SplineViolations>
+      <ScanFieldBoundariesViolated>false</ScanFieldBoundariesViolated>
+      <VelocityLimitViolated>false</VelocityLimitViolated>
+      <AccelerationLimitViolated>false</AccelerationLimitViolated>
+      <PixelCountOrDistanceViolated>false</PixelCountOrDistanceViolated>
+     </SplineViolations>
+    </SplineViolations>
+    <ImageFrame.Max Status="Valid" IsReadOnly="true">0,0,1024,1024</ImageFrame.Max>
+    <ImagePixelDistances Status="Valid" IsReadOnly="true">16.5728515625,16.5728515625</ImagePixelDistances>
+    <LiveImagePixelDistances Status="Valid" IsReadOnly="true">16.5728515625,16.5728515625</LiveImagePixelDistances>
+    <ScaledMaxImageSize Status="Valid" IsReadOnly="true">269.374603174603,269.374603174603</ScaledMaxImageSize>
+    <AiryScanBeamCentralizingQuality Status="Valid" IsReadOnly="true">Unknown</AiryScanBeamCentralizingQuality>
+    <TrackNumber Status="Valid"/>
+    <SimulateInService Status="Valid">false</SimulateInService>
+    <RoiRotation Status="Valid">0</RoiRotation>
+    <RoiCenterOffsetX Status="Valid">0</RoiCenterOffsetX>
+    <RoiCenterOffsetY Status="Valid">0</RoiCenterOffsetY>
+    <Zoom Status="Valid">1,1</Zoom>
+    <ScanSpeed Status="Valid">8</ScanSpeed>
+    <ScanFrequencyOverride Status="Valid">-1</ScanFrequencyOverride>
+    <ScanAreaMode Status="Valid">Frame</ScanAreaMode>
+    <FrameSize Status="Valid">512,512</FrameSize>
+    <FrameOffset Status="Valid">0,0</FrameOffset>
+    <SpotScanPixelAggregationSize Status="Valid">1000,1</SpotScanPixelAggregationSize>
+    <Frame Status="Valid">256,256,512,512</Frame>
+    <ImageFrame Status="Valid">256,256,512,512</ImageFrame>
+    <BitsPerPixel Status="Valid">8</BitsPerPixel>
+    <AveragingNumber Status="Valid">1</AveragingNumber>
+    <AveragingMethod Status="Valid">Mean</AveragingMethod>
+    <AveragingMode Status="Valid">Line</AveragingMode>
+    <HdrNumber Status="Valid">1</HdrNumber>
+    <HdrMethod Status="Valid">Illumination</HdrMethod>
+    <HdrIntensity Status="Valid">1</HdrIntensity>
+    <IsHdrActivated Status="Valid">false</IsHdrActivated>
+    <ScanDirection Status="Valid">Unidirectional</ScanDirection>
+    <ScannerCorrectionX Status="Valid">0</ScannerCorrectionX>
+    <ScannerCorrectionY Status="Valid">0</ScannerCorrectionY>
+    <TrackMultiplexType Status="Valid">Frame</TrackMultiplexType>
+    <LineStep Status="Valid">1</LineStep>
+    <LineStepInterpolation Status="Valid">false</LineStepInterpolation>
+    <ColumnStep Status="Valid">1</ColumnStep>
+    <UsesOnlineCalibration Status="Valid">false</UsesOnlineCalibration>
+    <DisableBlanking Status="Valid">false</DisableBlanking>
+    <HdrKeepRawImageData Status="Valid">true</HdrKeepRawImageData>
+    <DoAiryScanBeamCentralizingInContinuousScan Status="Valid">false</DoAiryScanBeamCentralizingInContinuousScan>
+    <DoAiryScanBeamCentralizingInSlowTimeSeries Status="Valid">false</DoAiryScanBeamCentralizingInSlowTimeSeries>
+    <AiryScanBeamCentralizingStoreSecondaryAdjustmentValues Status="Valid">false</AiryScanBeamCentralizingStoreSecondaryAdjustmentValues>
+    <SamplingMode Status="Valid">User</SamplingMode>
+    <Sampling Status="Valid">1</Sampling>
+    <ScaledImageRectangle Status="Valid">67.3436507936508,67.3436507936508,134.687301587302,134.687301587302</ScaledImageRectangle>
+    <ScaledImageRectangleSize Status="Valid">134.687301587302,134.687301587302</ScaledImageRectangleSize>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLEDArraySF_FF">
+    <LEDArrayContrastType Status="Valid">CentralLed</LEDArrayContrastType>
+    <SelectedLED Status="Valid">0</SelectedLED>
+    <Intensity Status="Valid">10</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <SelectedSubPattern Status="Valid">0</SelectedSubPattern>
+    <SubPatternCount Status="Valid">1</SubPatternCount>
+    <ProcessingMode Status="Valid">Minimum</ProcessingMode>
+    <IsSwitchedOn/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLEDArraySF_RL">
+    <LEDArrayContrastType Status="Valid">CentralLed</LEDArrayContrastType>
+    <SelectedLED Status="Valid">0</SelectedLED>
+    <Intensity Status="Valid">10</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <SelectedSubPattern Status="Valid">0</SelectedSubPattern>
+    <SubPatternCount Status="Valid">0</SubPatternCount>
+    <ProcessingMode Status="Valid">Minimum</ProcessingMode>
+    <IsSwitchedOn/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880OneWire1Sensor2">
+    <Position Status="Valid">23</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880OneWire1Sensor3">
+    <Position Status="Valid">23.19</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBFocusStabilizer2">
+    <Period Status="Valid">0</Period>
+    <IsStabilizingPeriodically Status="Valid">false</IsStabilizingPeriodically>
+    <Status Status="Valid">Standby</Status>
+    <IsInitialized Status="Valid">false</IsInitialized>
+    <DefiniteFocusSignalQuality Status="Valid">0</DefiniteFocusSignalQuality>
+    <DefiniteFocusPositionOffset Status="Valid">NaN</DefiniteFocusPositionOffset>
+    <DefiniteFocusOperationMode Status="Valid">Balanced</DefiniteFocusOperationMode>
+    <ObjectiveSuitability Status="Valid">Suitable</ObjectiveSuitability>
+    <IsStabilizingInLocateMode Status="Valid">false</IsStabilizingInLocateMode>
+    <DefiniteFocusResult Status="Valid">Success</DefiniteFocusResult>
+    <DefiniteFocusError>NoError</DefiniteFocusError>
+    <DefiniteFocusPosition>0</DefiniteFocusPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880OneWire2Sensor4">
+    <Position Status="Valid">23.75</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980MonitordiodeInternValue">
+    <Position Status="Valid">199.0149281</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980MonitordiodeExternValue">
+    <Position Status="Valid">228.4244372</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980LaserLine488">
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <Intensity Status="Valid">0.0010019910631792</Intensity>
+    <IsTuning Status="Valid" IsReadOnly="true">false</IsTuning>
+    <MaxPowerMilliWatts Status="Valid" IsReadOnly="true">13</MaxPowerMilliWatts>
+    <LaserLineStatus Status="Valid" IsReadOnly="true">NotSupported</LaserLineStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCamera_MTBCameraAdapter_MTBSideportChanger_Right"/>
+   <ParameterCollection Id="MTBCamera_MTBCameraAdapter_Preview"/>
+   <ParameterCollection Id="MTBCameraAdapter_MTBSideportChanger_Right">
+    <TheoreticalTotalMagnification Status="Valid" IsReadOnly="true">63</TheoreticalTotalMagnification>
+    <TotalAperture Status="Valid" IsReadOnly="true">1.4</TotalAperture>
+    <TotalMagnification Status="Valid" IsReadOnly="true">65.06075</TotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsReadOnly="true">µm</DefaultScalingUnit>
+    <LpPixelShift IsReadOnly="true"/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCameraAdapter_Preview">
+    <TheoreticalTotalMagnification Status="Valid" IsReadOnly="true">63</TheoreticalTotalMagnification>
+    <TotalAperture Status="Valid" IsReadOnly="true">1.4</TotalAperture>
+    <TotalMagnification Status="Valid" IsReadOnly="true">1</TotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsReadOnly="true">µm</DefaultScalingUnit>
+    <LpPixelShift IsReadOnly="true"/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCondenserContrastChanger">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Contrast.BrightField</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBCondenserProperties"/>
+   <ParameterCollection Id="MTBEyePiece">
+    <TheoreticalTotalMagnification Status="Valid" IsReadOnly="true">630</TheoreticalTotalMagnification>
+    <TotalAperture Status="Valid" IsReadOnly="true">1.4</TotalAperture>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBFocus">
+    <Position Status="Valid" Unit="µm">1901.641</Position>
+    <MeasurementPosition Status="Valid" IsReadOnly="true">1901.641</MeasurementPosition>
+    <LoadWorkPosition Status="Valid" IsReadOnly="true">Work</LoadWorkPosition>
+    <IsPrecise Status="Valid">true</IsPrecise>
+    <AxisSetPositionMode Status="Valid">Default</AxisSetPositionMode>
+    <Speed Status="Valid">0</Speed>
+    <ContinualSpeed Status="Valid">6000</ContinualSpeed>
+    <ContinualAcceleration Status="Valid">10000</ContinualAcceleration>
+    <IsHandwheelDeactivated Status="Valid">false</IsHandwheelDeactivated>
+    <IsLowerSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsLowerSWLimitEnabled>
+    <LowerSWLimit Status="Valid" IsReadOnly="true">-14000</LowerSWLimit>
+    <IsUpperSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsUpperSWLimitEnabled>
+    <UpperSWLimit Status="Valid" IsReadOnly="true">14000</UpperSWLimit>
+    <AxisCalibrationMode Status="Valid" IsReadOnly="true">NotCalibrated</AxisCalibrationMode>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBMicroscopeManager">
+    <ContrastManagerContrastMethod Status="Valid">TransmittedLightBrightfield</ContrastManagerContrastMethod>
+    <ContrastManagerMode Status="Valid">Off</ContrastManagerMode>
+    <LightManagerMode Status="Valid">Objective</LightManagerMode>
+    <IsCondenserFocusing Status="Valid">false</IsCondenserFocusing>
+    <IsCurrentFeed Status="Valid">false</IsCurrentFeed>
+    <IsDazzleProtection Status="Valid">true</IsDazzleProtection>
+    <IsLightManagerTemporary Status="Valid">false</IsLightManagerTemporary>
+    <IsLoadWorkCoupling Status="Valid">false</IsLoadWorkCoupling>
+    <IsVignettingFreeModeTemporary Status="Valid">false</IsVignettingFreeModeTemporary>
+    <IsLaserSafety Status="Valid" IsReadOnly="true">false</IsLaserSafety>
+    <IsParfocalCorrection Status="Valid">true</IsParfocalCorrection>
+    <IsParfocalCorrectionSilentMode Status="Valid">false</IsParfocalCorrectionSilentMode>
+    <IsParcentralCorrection Status="Valid">false</IsParcentralCorrection>
+    <IsParcentralCorrectionSilentMode Status="Valid">false</IsParcentralCorrectionSilentMode>
+    <IsParpolarizationCorrection Status="Valid">false</IsParpolarizationCorrection>
+    <IsParpolarizationCorrectionSilentMode Status="Valid">false</IsParpolarizationCorrectionSilentMode>
+    <ParfocalParcentralValues Status="Valid">
+     <ParfocalParcentralValues>
+      <ParfocalParcentralValue MTBObjectiveChanger="1">
+       <Parfocal>-2.37</Parfocal>
+       <ParcentralX>0</ParcentralX>
+       <ParcentralY>0</ParcentralY>
+      </ParfocalParcentralValue>
+      <ParfocalParcentralValue MTBObjectiveChanger="2">
+       <Parfocal>1.62</Parfocal>
+       <ParcentralX>-169.715</ParcentralX>
+       <ParcentralY>154.937</ParcentralY>
+      </ParfocalParcentralValue>
+      <ParfocalParcentralValue MTBObjectiveChanger="3">
+       <Parfocal>0</Parfocal>
+       <ParcentralX>0</ParcentralX>
+       <ParcentralY>0</ParcentralY>
+      </ParfocalParcentralValue>
+      <ParfocalParcentralValue MTBObjectiveChanger="4">
+       <Parfocal>0</Parfocal>
+       <ParcentralX>0</ParcentralX>
+       <ParcentralY>0</ParcentralY>
+      </ParfocalParcentralValue>
+      <ParfocalParcentralValue MTBObjectiveChanger="5">
+       <Parfocal>0</Parfocal>
+       <ParcentralX>0</ParcentralX>
+       <ParcentralY>0</ParcentralY>
+      </ParfocalParcentralValue>
+      <ParfocalParcentralValue MTBObjectiveChanger="6">
+       <Parfocal>0</Parfocal>
+       <ParcentralX>0</ParcentralX>
+       <ParcentralY>0</ParcentralY>
+      </ParfocalParcentralValue>
+     </ParfocalParcentralValues>
+    </ParfocalParcentralValues>
+    <UiDialogParameter Status="Valid">Unknown</UiDialogParameter>
+    <UiPopupParameter Status="Valid">Unknown</UiPopupParameter>
+    <IsObjectiveCorrFocusCorrection Status="Valid" IsReadOnly="true">false</IsObjectiveCorrFocusCorrection>
+    <IsObjectiveProtectionActive Status="Valid" IsReadOnly="true">false</IsObjectiveProtectionActive>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBObject"/>
+   <ParameterCollection Id="MTBObjectiveChanger">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">Objective.420782-9900-799</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBOptovarChanger">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">Aquila.Tubelens LSM</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBReflectorChanger">
+    <Position Status="Valid">6</Position>
+    <PositionName Status="Valid">Reflector.none</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBRLShutter">
+    <PositionName Status="Valid">Shutter.Closed</PositionName>
+    <IsClosed Status="Valid">true</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBRLTLSwitch">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">RLTLSwitch.TL</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBSideportChanger">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">Aquila.SideportElement_100%LSM</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBStage"/>
+   <ParameterCollection Id="MTBStageAxisX">
+    <Position Status="Valid" Unit="µm">6205.134</Position>
+    <MeasurementPosition Status="Valid" IsReadOnly="true">6205.134</MeasurementPosition>
+    <LoadWorkPosition Status="Valid" IsReadOnly="true">Work</LoadWorkPosition>
+    <IsPrecise Status="Valid">false</IsPrecise>
+    <AxisSetPositionMode Status="Valid">Default</AxisSetPositionMode>
+    <Speed Status="Valid">0</Speed>
+    <ContinualSpeed Status="Valid">25000</ContinualSpeed>
+    <ContinualAcceleration Status="Valid">500000</ContinualAcceleration>
+    <IsHandwheelDeactivated Status="Valid">false</IsHandwheelDeactivated>
+    <IsLowerSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsLowerSWLimitEnabled>
+    <LowerSWLimit Status="Valid" IsReadOnly="true">-350000</LowerSWLimit>
+    <IsUpperSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsUpperSWLimitEnabled>
+    <UpperSWLimit Status="Valid" IsReadOnly="true">350000</UpperSWLimit>
+    <AxisCalibrationMode Status="Valid" IsReadOnly="true">NotCalibrated</AxisCalibrationMode>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBStageAxisY">
+    <Position Status="Valid" Unit="µm">-2684.482</Position>
+    <MeasurementPosition Status="Valid" IsReadOnly="true">-2684.482</MeasurementPosition>
+    <LoadWorkPosition Status="Valid" IsReadOnly="true">Work</LoadWorkPosition>
+    <IsPrecise Status="Valid">false</IsPrecise>
+    <AxisSetPositionMode Status="Valid">Default</AxisSetPositionMode>
+    <Speed Status="Valid">0</Speed>
+    <ContinualSpeed Status="Valid">25000</ContinualSpeed>
+    <ContinualAcceleration Status="Valid">500000</ContinualAcceleration>
+    <IsHandwheelDeactivated Status="Valid">false</IsHandwheelDeactivated>
+    <IsLowerSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsLowerSWLimitEnabled>
+    <LowerSWLimit Status="Valid" IsReadOnly="true">-350000</LowerSWLimit>
+    <IsUpperSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsUpperSWLimitEnabled>
+    <UpperSWLimit Status="Valid" IsReadOnly="true">350000</UpperSWLimit>
+    <AxisCalibrationMode Status="Valid" IsReadOnly="true">NotCalibrated</AxisCalibrationMode>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBTLApertureStop">
+    <Position Status="Valid" Unit="NA">0.55</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBTLHalogenLamp">
+    <Intensity Status="Valid">0.17906066536204</Intensity>
+    <LampMode Status="Valid">Standby</LampMode>
+    <LampActive Status="Valid" IsReadOnly="true">true</LampActive>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBTLShutter">
+    <PositionName Status="Valid">Shutter.Closed</PositionName>
+    <IsClosed Status="Valid">true</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBPiezoFocusCan">
+    <Position Status="Valid" Unit="µm">250.011</Position>
+    <MeasurementPosition Status="Valid" IsReadOnly="true">250.011</MeasurementPosition>
+    <LoadWorkPosition Status="Valid" IsReadOnly="true">Work</LoadWorkPosition>
+    <IsPrecise Status="Valid">true</IsPrecise>
+    <AxisSetPositionMode Status="Valid">Default</AxisSetPositionMode>
+    <Speed Status="Valid">0</Speed>
+    <ContinualSpeed Status="Valid">5000</ContinualSpeed>
+    <ContinualAcceleration Status="Valid">0</ContinualAcceleration>
+    <IsHandwheelDeactivated Status="Valid">true</IsHandwheelDeactivated>
+    <IsLowerSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsLowerSWLimitEnabled>
+    <LowerSWLimit Status="Valid" IsReadOnly="true">0</LowerSWLimit>
+    <IsUpperSWLimitEnabled Status="Valid" IsReadOnly="true">true</IsUpperSWLimitEnabled>
+    <UpperSWLimit Status="Valid" IsReadOnly="true">500</UpperSWLimit>
+    <AxisCalibrationMode Status="Valid" IsReadOnly="true">OnLowerLimit, AutomaticallyCalibrated</AxisCalibrationMode>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880HealthStatus"/>
+   <ParameterCollection Id="MTBLSM880InternalDetectors"/>
+   <ParameterCollection Id="MTBSensorLogging"/>
+   <ParameterCollection Id="MTBLSM880ShutterInvis">
+    <PositionName Status="Valid">Shutter.Open</PositionName>
+    <IsClosed Status="Valid">false</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ShutterVis">
+    <PositionName Status="Valid">Shutter.Open</PositionName>
+    <IsClosed Status="Valid">false</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SafetyControl710Laser543OnOff">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Laser.Off</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SafetyControl710Laser594OnOff">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Laser.Off</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SafetyControl710Laser633OnOff">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Laser.Off</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SafetyControl710PortExpander1"/>
+   <ParameterCollection Id="MTBLSM880SafetyControl710PortExpander2"/>
+   <ParameterCollection Id="MTBLSM880SafetyControl710PortExpander3"/>
+   <ParameterCollection Id="MTBLSM880SafetyControl710PortExpander4"/>
+   <ParameterCollection Id="MTBLSM880MetaDiscriCoarseCh34DAC">
+    <Position Status="Valid">-0.003921568627451</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MetaDiscriCoarseCh35DAC">
+    <Position Status="Valid">-0.003921568627451</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MetaHvOverloadStatus"/>
+   <ParameterCollection Id="MTBLSM880LaserCouplingInvis"/>
+   <ParameterCollection Id="MTBLSM880LaserCouplingVis"/>
+   <ParameterCollection Id="MTBLSM880MbsInvis">
+    <Position Status="Valid">3</Position>
+    <PositionName Status="Valid">Beamsplitter.1520-117</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MbsVis">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">Beamsplitter.2412-349</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880OneWire1PortExpander"/>
+   <ParameterCollection Id="MTBLSM880OneWire1Sensor4">
+    <Position Status="Valid">21.25</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880OneWire2PortExpander"/>
+   <ParameterCollection Id="MTBLSM880MetaCh32PeltierOnOff">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">On</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MetaCh32TargetTempPeltier">
+    <Position Status="Valid">10</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MetaCh34PeltierOnOff">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">On</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880MetaCh34TargetTempPeltier">
+    <Position Status="Valid">15</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ExternalDetectors"/>
+   <ParameterCollection Id="MTBLSM880SRModule"/>
+   <ParameterCollection Id="MTBLSM880SRModulHealthStatus"/>
+   <ParameterCollection Id="MTBLSM880SRPeltierOnOff">
+    <Position Status="Valid">2</Position>
+    <PositionName Status="Valid">On</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SRTargetTempPeltier">
+    <Position Status="Valid">15</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SRHvOverloadStatus"/>
+   <ParameterCollection Id="AlbireoLEDController">
+    <LampMode Status="Valid">LEDContinuous</LampMode>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLED1">
+    <Intensity Status="Valid" Unit="%">5</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLED3">
+    <Intensity Status="Valid" Unit="%">75</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLED5">
+    <Intensity Status="Valid" Unit="%">75</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLED6">
+    <Intensity Status="Valid" Unit="%">0.1</Intensity>
+    <IsEnabled Status="Valid">false</IsEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBTLLampChanger">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Mirror.Left</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLaserModuleLKM980HealthStatus"/>
+   <ParameterCollection Id="MTBLKM980Mainboard"/>
+   <ParameterCollection Id="MTBLKM980Shutter445">
+    <PositionName Status="Valid">Shutter.Closed</PositionName>
+    <IsClosed Status="Valid">true</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Shutter488">
+    <PositionName Status="Valid">Shutter.Open</PositionName>
+    <IsClosed Status="Valid">false</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Shutter514">
+    <PositionName Status="Valid">Shutter.Closed</PositionName>
+    <IsClosed Status="Valid">true</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Shutter561">
+    <PositionName Status="Valid">Shutter.Open</PositionName>
+    <IsClosed Status="Valid">false</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Shutter594">
+    <PositionName Status="Valid">Shutter.Closed</PositionName>
+    <IsClosed Status="Valid">true</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Shutter639">
+    <PositionName Status="Valid">Shutter.Open</PositionName>
+    <IsClosed Status="Valid">false</IsClosed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBOverallSafety"/>
+   <ParameterCollection Id="MTBIncubationCalibrationSensor">
+    <Position Status="Valid" Unit="°C">-0.1</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationTemperatureChannel1">
+    <Position Status="Valid">37</Position>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <CurrentPosition Status="Valid" IsReadOnly="true" Unit="°C">21.5</CurrentPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationTemperatureChannel2">
+    <Position Status="Valid">37</Position>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <CurrentPosition Status="Valid" IsReadOnly="true" Unit="°C">-0.1</CurrentPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationTemperatureChannel3">
+    <Position Status="Valid">27</Position>
+    <IsEnabled Status="Valid">true</IsEnabled>
+    <CurrentPosition Status="Valid" IsReadOnly="true" Unit="°C">27</CurrentPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationTemperatureChannel4">
+    <Position Status="Valid">37</Position>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <CurrentPosition Status="Valid" IsReadOnly="true" Unit="°C">21.3</CurrentPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationCO2Channel">
+    <Position Status="Valid">5</Position>
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <CurrentPosition Status="Valid" IsReadOnly="true" Unit="%">-0.1</CurrentPosition>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBIncubationCO2Fan">
+    <Position Status="Valid" Unit="Level">4</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBMicoIFHSTemperature">
+    <Position Status="Valid">38</Position>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBRTRtNotification"/>
+   <ParameterCollection Id="SoftwareAutofocus">
+    <IsInitialized Status="Valid">true</IsInitialized>
+    <IsRunning Status="Valid">false</IsRunning>
+    <AutofocusResult Status="Valid">Undefined</AutofocusResult>
+    <AutofocusSignalQuality Status="Valid">0</AutofocusSignalQuality>
+    <AutofocusAnalysisData Status="Valid"/>
+   </ParameterCollection>
+   <ParameterCollection Id="Autofocus">
+    <IsInitialized Status="Valid">true</IsInitialized>
+    <IsRunning Status="Valid">false</IsRunning>
+    <AutofocusResult Status="Valid">Undefined</AutofocusResult>
+    <AutofocusSignalQuality Status="Valid">0</AutofocusSignalQuality>
+    <AutofocusStrategyMode Status="Valid">Software</AutofocusStrategyMode>
+    <AutofocusSignalQualityThreshold Status="Valid">50</AutofocusSignalQualityThreshold>
+   </ParameterCollection>
+   <ParameterCollection Id="Incubation"/>
+   <ParameterCollection Id="IOCard">
+    <DigitalOutValue1 Status="Valid">false</DigitalOutValue1>
+    <DigitalOutMode1 Status="Valid">RisingEdge</DigitalOutMode1>
+    <DigitalOutDelay1 Status="Valid">0</DigitalOutDelay1>
+    <DigitalOutValue2 Status="Valid">false</DigitalOutValue2>
+    <DigitalOutMode2 Status="Valid">RisingEdge</DigitalOutMode2>
+    <DigitalOutDelay2 Status="Valid">0</DigitalOutDelay2>
+    <DigitalOutValue3 Status="Valid">false</DigitalOutValue3>
+    <DigitalOutMode3 Status="Valid">RisingEdge</DigitalOutMode3>
+    <DigitalOutDelay3 Status="Valid">0</DigitalOutDelay3>
+    <DigitalOutValue4 Status="Valid">false</DigitalOutValue4>
+    <DigitalOutMode4 Status="Valid">RisingEdge</DigitalOutMode4>
+    <DigitalOutDelay4 Status="Valid">0</DigitalOutDelay4>
+    <DigitalIn1 Status="Valid" IsReadOnly="true">false</DigitalIn1>
+    <DigitalIn2 Status="Valid" IsReadOnly="true">false</DigitalIn2>
+    <DigitalIn3 Status="Valid" IsReadOnly="true">false</DigitalIn3>
+    <DigitalIn4 Status="Valid" IsReadOnly="true">false</DigitalIn4>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBScanheadAdapter_Left">
+    <TheoreticalTotalMagnification Status="Valid" IsReadOnly="true">63</TheoreticalTotalMagnification>
+    <TotalAperture Status="Valid" IsReadOnly="true">1.4</TotalAperture>
+    <TotalMagnification Status="Valid" IsReadOnly="true">63</TotalMagnification>
+    <DefaultScalingUnit Status="Valid" IsReadOnly="true">µm</DefaultScalingUnit>
+    <LpPixelShift IsReadOnly="true"/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880InternalDetectorsMirror"/>
+   <ParameterCollection Id="MTBLSM880ReadbackDetectorX"/>
+   <ParameterCollection Id="MTBLSM880ReadbackDetectorY"/>
+   <ParameterCollection Id="MTBLSM880ScannerDevice">
+    <BleachInProgress Status="Valid">false</BleachInProgress>
+    <ImageFlip Status="Valid">ExchangeXY, MirrorX, MirrorY</ImageFlip>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ScannerX"/>
+   <ParameterCollection Id="MTBLSM880ScannerY"/>
+   <ParameterCollection Id="MTBLSM880ScannerZ"/>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorVisXAxis">
+    <Position Status="Valid" Unit="µm" AlternativeUnit="%|43.343343343343|Steps|434|">-75.9</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorVisYAxis">
+    <Position Status="Valid" Unit="µm" AlternativeUnit="%|54.754754754755|Steps|548|">66.24</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PinholeDiameterCollimatingLens"/>
+   <ParameterCollection Id="MTBLSM880PinholeDiameter">
+    <Position Status="Valid" Unit="µm" AlternativeUnit="%|29.193899782135|Steps|135|">42.85513159918</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorInvisXAxis">
+    <Position Status="Valid" Unit="µm" AlternativeUnit="%|35.235235235235|Steps|353|">-169.05</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorInvisYAxis">
+    <Position Status="Valid" Unit="µm" AlternativeUnit="%|46.546546546547|Steps|466|">-46.92</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880DetectorLong">
+    <DetectorGain Status="SuperValid" IsActivated="true" Unit="V" AlternativeUnit="HvGain|5.2520188782734E-09|">650</DetectorGain>
+    <IsHighVoltageOverloaded Status="SuperValid" IsReadOnly="true">false</IsHighVoltageOverloaded>
+    <IsEnabled Status="SuperValid" IsActivated="true">false</IsEnabled>
+    <IsHvEnabled Status="SuperValid" IsActivated="true">true</IsHvEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880DetectorShort">
+    <DetectorGain Status="SuperValid" IsActivated="true" Unit="V" AlternativeUnit="HvGain|9.1317515396643E-09|">650</DetectorGain>
+    <IsHighVoltageOverloaded Status="SuperValid" IsReadOnly="true">false</IsHighVoltageOverloaded>
+    <IsEnabled Status="SuperValid" IsActivated="true">false</IsEnabled>
+    <IsHvEnabled Status="SuperValid" IsActivated="true">true</IsHvEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880CollimatorInvis1">
+    <Position Status="Valid" Unit="mm" AlternativeUnit="%|62.713120830245|Steps|847|">-0.040625</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SRMetaDetector">
+    <DetectorGain Status="SuperValid" IsActivated="true">700</DetectorGain>
+    <IsHighVoltageOverloaded Status="SuperValid" IsReadOnly="true">false</IsHighVoltageOverloaded>
+    <IsEnabled Status="SuperValid">false</IsEnabled>
+    <IsHvEnabled Status="SuperValid" IsActivated="true">false</IsHvEnabled>
+    <DeactivateCrosstalkCorrection Status="Valid"/>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PinholeSR"/>
+   <ParameterCollection Id="MTBLSM880PinholeSRXAxis">
+    <Position Status="Valid" Unit="%" AlternativeUnit="µrad|216|Steps|518|">51.751751751752</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PinholeSRYAxis">
+    <Position Status="Valid" Unit="%" AlternativeUnit="µrad|308|Steps|478|">47.747747747748</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880EmissionFilterSR">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Beamsplitter.Plate</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLaserModuleLKM980"/>
+   <ParameterCollection Id="CalibrationComponent_MTBLaserModuleLKM980">
+    <Task_-_0_---__--_Progress Status="Valid">-1</Task_-_0_---__--_Progress>
+    <Task_-_0_---__--_Progress_--_Result Status="SuperValid">0 : not run</Task_-_0_---__--_Progress_--_Result>
+    <Task_-_1_---__--_Progress Status="Valid">-1</Task_-_1_---__--_Progress>
+    <Task_-_1_---__--_Progress_--_Result Status="SuperValid">0 : not run</Task_-_1_---__--_Progress_--_Result>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Laser405">
+    <IsEnabled Status="Valid">true</IsEnabled>
+    <IsWarmingUp Status="Valid" IsReadOnly="true">false</IsWarmingUp>
+    <Wavelength Status="Valid">0</Wavelength>
+    <LaserEnableTime Status="Valid" IsReadOnly="true">1173600</LaserEnableTime>
+    <LaserStatus Status="Valid" IsReadOnly="true">Ready</LaserStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Laser639">
+    <IsEnabled Status="Valid">true</IsEnabled>
+    <IsWarmingUp Status="Valid" IsReadOnly="true">false</IsWarmingUp>
+    <Wavelength Status="Valid">0</Wavelength>
+    <LaserEnableTime Status="Valid" IsReadOnly="true">1332900</LaserEnableTime>
+    <LaserStatus Status="Valid" IsReadOnly="true">Ready</LaserStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980LaserLine405">
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <Intensity Status="Valid">0.20013042830022</Intensity>
+    <IsTuning Status="Valid" IsReadOnly="true">false</IsTuning>
+    <MaxPowerMilliWatts Status="Valid" IsReadOnly="true">15</MaxPowerMilliWatts>
+    <LaserLineStatus Status="Valid" IsReadOnly="true">NotSupported</LaserLineStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980LaserLine639">
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <Intensity Status="Valid">0.0010019910631792</Intensity>
+    <IsTuning Status="Valid" IsReadOnly="true">false</IsTuning>
+    <MaxPowerMilliWatts Status="Valid" IsReadOnly="true">10</MaxPowerMilliWatts>
+    <LaserLineStatus Status="Valid" IsReadOnly="true">NotSupported</LaserLineStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980Laser488">
+    <IsEnabled Status="Valid">true</IsEnabled>
+    <IsWarmingUp Status="Valid" IsReadOnly="true">false</IsWarmingUp>
+    <Wavelength Status="Valid">0</Wavelength>
+    <LaserEnableTime Status="Valid" IsReadOnly="true">1665000</LaserEnableTime>
+    <LaserStatus Status="Valid" IsReadOnly="true">Ready</LaserStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLKM980LaserLine561">
+    <IsEnabled Status="Valid">false</IsEnabled>
+    <Intensity Status="Valid">0.0010019910631792</Intensity>
+    <IsTuning Status="Valid" IsReadOnly="true">false</IsTuning>
+    <MaxPowerMilliWatts Status="Valid" IsReadOnly="true">13</MaxPowerMilliWatts>
+    <LaserLineStatus Status="Valid" IsReadOnly="true">NotSupported</LaserLineStatus>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880LaserSafetyManager"/>
+   <ParameterCollection Id="MTBRTGlobalSettingsManager"/>
+   <ParameterCollection Id="MTBRTHardwareAdmin"/>
+   <ParameterCollection Id="RealtimeSystem"/>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorVis"/>
+   <ParameterCollection Id="MTBLSM880BeamshiftCompensatorInvis"/>
+   <ParameterCollection Id="MTBLSM880PinLong">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|1|%|0|">757.54198473282</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PinShort">
+    <Position Status="SuperValid" Unit="nm" AlternativeUnit="Steps|1|%|0|">375.44292237443</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880SpectralGroup">
+    <OperationMode Status="Valid" IsActivated="true">Channel</OperationMode>
+    <Bands Status="Valid" IsActivated="true">
+     <Bands>
+      <BandState>
+       <Left>407.5</Left>
+       <Right>500.31939697265625</Right>
+       <IsFixed>false</IsFixed>
+       <DetectorId>short</DetectorId>
+      </BandState>
+      <BandState>
+       <Left>641.5</Left>
+       <Right>757.97205091502565</Right>
+       <IsFixed>false</IsFixed>
+       <DetectorId>long</DetectorId>
+      </BandState>
+     </Bands>
+    </Bands>
+    <LaserBlocker0 Status="Valid" IsActivated="true">-1</LaserBlocker0>
+    <LaserBlocker1 Status="Valid" IsActivated="true">-1</LaserBlocker1>
+    <LambdaModeCenterWavelength Status="Valid" IsActivated="true">-1</LambdaModeCenterWavelength>
+    <LambdaModeSlitWidth Status="Valid" IsActivated="true">-1</LambdaModeSlitWidth>
+    <ReflectionEnabled Status="Valid" IsActivated="true">false</ReflectionEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ApertureLong">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|25|%|1.4397120575885|">757.97205091503</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ApertureShort">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|170|%|10.137972405519|">407.53352970515</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PrismLong">
+    <Position Status="SuperValid" Unit="nm" AlternativeUnit="Steps|510|%|30.406212664277|">641.47535758984</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880PrismShort">
+    <Position Status="SuperValid" Unit="nm" AlternativeUnit="Steps|605|%|36.081242532855|">500.26030890292</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880WedgeLong">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|1|%|0|">7.9613360530709</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880WedgeShort">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|1|%|0|">-7.6406901757049</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880Grating">
+    <Position Status="Valid" Unit="nm" AlternativeUnit="Steps|257|%|49.805447470817|">551.84118928717</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880BeamShaperWheelInvis">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Beamshape.Circle1</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880BeamShaperWheelVis">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">Beamshape.Circle1</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880DetectorMeta">
+    <DetectorGain Status="SuperValid" IsActivated="true" Unit="V" AlternativeUnit="HvGain|1.3120297394492E-08|">650</DetectorGain>
+    <IsHighVoltageOverloaded Status="SuperValid" IsReadOnly="true">false</IsHighVoltageOverloaded>
+    <IsEnabled Status="SuperValid" IsActivated="true">false</IsEnabled>
+    <IsHvEnabled Status="SuperValid" IsActivated="true">true</IsHvEnabled>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880Sbs">
+    <Position Status="Valid">1</Position>
+    <PositionName Status="Valid">SecondaryBeamsplitter.453001-4023-000</PositionName>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ZoomSRL2">
+    <Position Status="Valid" Unit="%">8.7445927717568</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ZoomSRL4">
+    <Position Status="Valid" Unit="%">14.051170930911</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="MTBLSM880ZoomSRMag">
+    <Position Status="Valid" Unit="mm" AlternativeUnit="%|0|Steps|750|">67.971158082095</Position>
+    <Speed Status="Valid">0</Speed>
+   </ParameterCollection>
+   <ParameterCollection Id="FcsRealTimeSystem"/>
+   <ParameterCollection Id="LaserLifetimeSavingComponent"/>
+   <Configuration>
+    <Device Id="Microscope" Name="Axio Observer.Z1 / 7" UniqueName="AquilaZ.Stand" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" ConfigurationName="2842001059">
+     <StandSpecification>
+      <StandCharacteristic Key="InvertedFixedStage"/>
+      <StandCharacteristic Key="SampleFinder"/>
+      <StandCharacteristic Key="LSM"/>
+     </StandSpecification>
+     <Devices>
+      <DeviceRef Id="MTBCameraAdapter_MTBSideportChanger_Right"/>
+      <DeviceRef Id="MTBCameraAdapter_Preview"/>
+      <DeviceRef Id="MTBCondenserContrastChanger"/>
+      <DeviceRef Id="MTBCondenserProperties"/>
+      <DeviceRef Id="MTBEyePiece"/>
+      <DeviceRef Id="MTBFocus"/>
+      <DeviceRef Id="MTBMicroscopeManager"/>
+      <DeviceRef Id="MTBObject"/>
+      <DeviceRef Id="MTBObjectiveChanger"/>
+      <DeviceRef Id="MTBOptovarChanger"/>
+      <DeviceRef Id="MTBReflectorChanger"/>
+      <DeviceRef Id="MTBRLShutter"/>
+      <DeviceRef Id="MTBRLTLSwitch"/>
+      <DeviceRef Id="MTBSideportChanger"/>
+      <DeviceRef Id="MTBStage"/>
+      <DeviceRef Id="MTBStageAxisX"/>
+      <DeviceRef Id="MTBStageAxisY"/>
+      <DeviceRef Id="MTBTLApertureStop"/>
+      <DeviceRef Id="MTBTLHalogenLamp"/>
+      <DeviceRef Id="MTBTLShutter"/>
+      <DeviceRef Id="MTBLEDArraySF_TL"/>
+      <DeviceRef Id="MTBLEDArraySF_FF"/>
+      <DeviceRef Id="MTBCondenserRLTempSensor"/>
+      <DeviceRef Id="MTBLEDArraySF_RL"/>
+      <DeviceRef Id="MTBFocusStabilizer2"/>
+      <DeviceRef Id="MTBPiezoFocusCan"/>
+      <DeviceRef Id="MTBLSM880HealthStatus"/>
+      <DeviceRef Id="MTBLSM880InternalDetectors"/>
+      <DeviceRef Id="MTBSensorLogging"/>
+      <DeviceRef Id="MTBLSM880ShutterInvis"/>
+      <DeviceRef Id="MTBLSM880ShutterVis"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710Laser543OnOff"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710Laser594OnOff"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710Laser633OnOff"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710PortExpander1"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710PortExpander2"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710PortExpander3"/>
+      <DeviceRef Id="MTBLSM880SafetyControl710PortExpander4"/>
+      <DeviceRef Id="MTBLSM880MetaDiscriCoarseCh34DAC"/>
+      <DeviceRef Id="MTBLSM880MetaDiscriCoarseCh35DAC"/>
+      <DeviceRef Id="MTBLSM880MetaHvOverloadStatus"/>
+      <DeviceRef Id="MTBLSM880LaserCouplingInvis"/>
+      <DeviceRef Id="MTBLSM880LaserCouplingVis"/>
+      <DeviceRef Id="MTBLSM880MbsInvis"/>
+      <DeviceRef Id="MTBLSM880MbsVis"/>
+      <DeviceRef Id="MTBLSM880OneWire1PortExpander"/>
+      <DeviceRef Id="MTBLSM880OneWire1Sensor2"/>
+      <DeviceRef Id="MTBLSM880OneWire1Sensor3"/>
+      <DeviceRef Id="MTBLSM880OneWire1Sensor4"/>
+      <DeviceRef Id="MTBLSM880OneWire2PortExpander"/>
+      <DeviceRef Id="MTBLSM880OneWire2Sensor4"/>
+      <DeviceRef Id="MTBLSM880MetaCh32PeltierOnOff"/>
+      <DeviceRef Id="MTBLSM880MetaCh32TargetTempPeltier"/>
+      <DeviceRef Id="MTBLSM880MetaCh34PeltierOnOff"/>
+      <DeviceRef Id="MTBLSM880MetaCh34TargetTempPeltier"/>
+      <DeviceRef Id="MTBLSM880ExternalDetectors"/>
+      <DeviceRef Id="MTBLSM880SRModule"/>
+      <DeviceRef Id="MTBLSM880SRModulHealthStatus"/>
+      <DeviceRef Id="MTBLSM880SRPeltierOnOff"/>
+      <DeviceRef Id="MTBLSM880SRTargetTempPeltier"/>
+      <DeviceRef Id="MTBLSM880SRHvOverloadStatus"/>
+      <DeviceRef Id="AlbireoLEDController"/>
+      <DeviceRef Id="MTBLED1"/>
+      <DeviceRef Id="MTBLED3"/>
+      <DeviceRef Id="MTBLED5"/>
+      <DeviceRef Id="MTBLED6"/>
+      <DeviceRef Id="MTBTLLampChanger"/>
+      <DeviceRef Id="MTBLaserModuleLKM980HealthStatus"/>
+      <DeviceRef Id="MTBLKM980Mainboard"/>
+      <DeviceRef Id="MTBLKM980Shutter445"/>
+      <DeviceRef Id="MTBLKM980Shutter488"/>
+      <DeviceRef Id="MTBLKM980Shutter514"/>
+      <DeviceRef Id="MTBLKM980Shutter561"/>
+      <DeviceRef Id="MTBLKM980Shutter594"/>
+      <DeviceRef Id="MTBLKM980Shutter639"/>
+      <DeviceRef Id="MTBLKM980Laser561WarmupProgress"/>
+      <DeviceRef Id="MTBLKM980MonitordiodeInternValue"/>
+      <DeviceRef Id="MTBLKM980MonitordiodeExternValue"/>
+      <DeviceRef Id="MTBOverallSafety"/>
+      <DeviceRef Id="MTBIncubationCalibrationSensor"/>
+      <DeviceRef Id="MTBIncubationTemperatureChannel1"/>
+      <DeviceRef Id="MTBIncubationTemperatureChannel2"/>
+      <DeviceRef Id="MTBIncubationTemperatureChannel3"/>
+      <DeviceRef Id="MTBIncubationTemperatureChannel4"/>
+      <DeviceRef Id="MTBIncubationCO2Channel"/>
+      <DeviceRef Id="MTBIncubationCO2Fan"/>
+      <DeviceRef Id="MTBMicoIFHSTemperature"/>
+      <DeviceRef Id="MTBRTRtNotification"/>
+      <DeviceRef Id="MTBObject"/>
+      <DeviceRef Id="Condenser"/>
+      <DeviceRef Id="Condenser"/>
+      <DeviceRef Id="MTBCamera_Preview.See3CAM_130"/>
+      <DeviceRef Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m"/>
+      <DeviceRef Id="SoftwareAutofocus"/>
+      <DeviceRef Id="Autofocus"/>
+      <DeviceRef Id="Incubation"/>
+      <DeviceRef Id="IOCard"/>
+      <DeviceRef Id="MTBScanheadAdapter_Left"/>
+      <DeviceRef Id="MTBLSM880InternalDetectorsMirror"/>
+      <DeviceRef Id="MTBLSM880ReadbackDetectorX"/>
+      <DeviceRef Id="MTBLSM880ReadbackDetectorY"/>
+      <DeviceRef Id="MTBLSM880ScannerDevice"/>
+      <DeviceRef Id="MTBLSM880ScannerX"/>
+      <DeviceRef Id="MTBLSM880ScannerY"/>
+      <DeviceRef Id="MTBLSM880ScannerZ"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorVisXAxis"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorVisYAxis"/>
+      <DeviceRef Id="MTBLSM880PinholeDiameterCollimatingLens"/>
+      <DeviceRef Id="MTBLSM880PinholeDiameter"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorInvisXAxis"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorInvisYAxis"/>
+      <DeviceRef Id="MTBLSM880DetectorLong"/>
+      <DeviceRef Id="MTBLSM880DetectorShort"/>
+      <DeviceRef Id="MTBLSM880CollimatorInvis1"/>
+      <DeviceRef Id="MTBLSM880SRMetaDetector"/>
+      <DeviceRef Id="MTBLSM880PinholeSR"/>
+      <DeviceRef Id="MTBLSM880PinholeSRXAxis"/>
+      <DeviceRef Id="MTBLSM880PinholeSRYAxis"/>
+      <DeviceRef Id="MTBLSM880EmissionFilterSR"/>
+      <DeviceRef Id="MTBLaserModuleLKM980"/>
+      <DeviceRef Id="CalibrationComponent_MTBLaserModuleLKM980"/>
+      <DeviceRef Id="MTBLKM980Laser405"/>
+      <DeviceRef Id="MTBLKM980Laser639"/>
+      <DeviceRef Id="MTBLKM980LaserLine405"/>
+      <DeviceRef Id="MTBLKM980LaserLine639"/>
+      <DeviceRef Id="MTBLKM980Laser488"/>
+      <DeviceRef Id="MTBLKM980Laser561"/>
+      <DeviceRef Id="MTBLKM980LaserLine488"/>
+      <DeviceRef Id="MTBLKM980LaserLine561"/>
+      <DeviceRef Id="MTBLSM880LaserSafetyManager"/>
+      <DeviceRef Id="MTBRTGlobalSettingsManager"/>
+      <DeviceRef Id="MTBRTHardwareAdmin"/>
+      <DeviceRef Id="RealtimeSystem"/>
+      <DeviceRef Id="MTBLSMImagingDevice"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorVis"/>
+      <DeviceRef Id="MTBLSM880BeamshiftCompensatorInvis"/>
+      <DeviceRef Id="MTBLSM880PinLong"/>
+      <DeviceRef Id="MTBLSM880PinShort"/>
+      <DeviceRef Id="MTBLSM880SpectralGroup"/>
+      <DeviceRef Id="MTBLSM880ApertureLong"/>
+      <DeviceRef Id="MTBLSM880ApertureShort"/>
+      <DeviceRef Id="MTBLSM880PrismLong"/>
+      <DeviceRef Id="MTBLSM880PrismShort"/>
+      <DeviceRef Id="MTBLSM880WedgeLong"/>
+      <DeviceRef Id="MTBLSM880WedgeShort"/>
+      <DeviceRef Id="MTBLSM880Grating"/>
+      <DeviceRef Id="MTBLSM880BeamShaperWheelInvis"/>
+      <DeviceRef Id="MTBLSM880BeamShaperWheelVis"/>
+      <DeviceRef Id="MTBLSM880DetectorMeta"/>
+      <DeviceRef Id="MTBLSM880Sbs"/>
+      <DeviceRef Id="MTBLSM880ZoomSRL2"/>
+      <DeviceRef Id="MTBLSM880ZoomSRL4"/>
+      <DeviceRef Id="MTBLSM880ZoomSRMag"/>
+      <DeviceRef Id="FcsRealTimeSystem"/>
+     </Devices>
+     <BeamPaths>
+      <BeamPath Key="ObservationPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="MTBObjectiveChanger">
+          <Successors>
+           <BeamPathNode Id="MTBReflectorChanger">
+            <Successors>
+             <BeamPathNode Id="MTBOptovarChanger">
+              <Successors>
+               <BeamPathNode Id="MTBSideportChanger">
+                <Successors>
+                 <BeamPathNode Id="MTBCameraAdapter_MTBSideportChanger_Right">
+                  <Successors>
+                   <BeamPathNode Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m">
+                    <Successors/>
+                   </BeamPathNode>
+                  </Successors>
+                 </BeamPathNode>
+                 <BeamPathNode Id="MTBEyePiece">
+                  <Successors/>
+                 </BeamPathNode>
+                 <BeamPathNode Id="MTBScanheadAdapter_Left">
+                  <Successors>
+                   <BeamPathNode Id="MTBLSMImagingDevice">
+                    <Successors>
+                     <BeamPathNode Id="MTBLSM880ScannerDevice">
+                      <Successors>
+                       <BeamPathNode Id="MTBLSM880MbsInvis">
+                        <Successors>
+                         <BeamPathNode Id="MTBLSM880MbsVis">
+                          <Successors>
+                           <BeamPathNode Id="MTBLSM880PinholeDiameter">
+                            <Successors>
+                             <BeamPathNode Id="MTBLSM880PinholeDiameterCollimatingLens">
+                              <Successors>
+                               <BeamPathNode Id="MTBLSM880Sbs">
+                                <Successors>
+                                 <BeamPathNode Id="MTBLSM880InternalDetectors">
+                                  <Successors>
+                                   <BeamPathNode Id="MTBLSM880InternalDetectorsMirror">
+                                    <Successors>
+                                     <BeamPathNode Id="MTBLSM880Grating">
+                                      <Successors>
+                                       <BeamPathNode Id="MTBLSM880SpectralGroup">
+                                        <Successors>
+                                         <BeamPathNode Id="MTBLSM880DetectorLong">
+                                          <Successors/>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLSM880DetectorMeta">
+                                          <Successors/>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLSM880DetectorShort">
+                                          <Successors/>
+                                         </BeamPathNode>
+                                        </Successors>
+                                       </BeamPathNode>
+                                      </Successors>
+                                     </BeamPathNode>
+                                    </Successors>
+                                   </BeamPathNode>
+                                  </Successors>
+                                 </BeamPathNode>
+                                 <BeamPathNode Id="MTBLSM880ExternalDetectors">
+                                  <Successors>
+                                   <BeamPathNode Id="MTBLSM880PinholeSR">
+                                    <Successors>
+                                     <BeamPathNode Id="MTBLSM880EmissionFilterSR">
+                                      <Successors>
+                                       <BeamPathNode Id="MTBLSM880ZoomSRMag">
+                                        <Successors>
+                                         <BeamPathNode Id="MTBLSM880SRMetaDetector">
+                                          <Successors/>
+                                         </BeamPathNode>
+                                        </Successors>
+                                       </BeamPathNode>
+                                      </Successors>
+                                     </BeamPathNode>
+                                    </Successors>
+                                   </BeamPathNode>
+                                  </Successors>
+                                 </BeamPathNode>
+                                </Successors>
+                               </BeamPathNode>
+                              </Successors>
+                             </BeamPathNode>
+                            </Successors>
+                           </BeamPathNode>
+                          </Successors>
+                         </BeamPathNode>
+                        </Successors>
+                       </BeamPathNode>
+                      </Successors>
+                     </BeamPathNode>
+                    </Successors>
+                   </BeamPathNode>
+                  </Successors>
+                 </BeamPathNode>
+                </Successors>
+               </BeamPathNode>
+              </Successors>
+             </BeamPathNode>
+            </Successors>
+           </BeamPathNode>
+          </Successors>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="ReflectedLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="MTBObjectiveChanger">
+          <Successors>
+           <BeamPathNode Id="MTBReflectorChanger">
+            <Successors>
+             <BeamPathNode Id="MTBOptovarChanger">
+              <Successors>
+               <BeamPathNode Id="MTBSideportChanger">
+                <Successors>
+                 <BeamPathNode Id="MTBScanheadAdapter_Left">
+                  <Successors>
+                   <BeamPathNode Id="MTBLSMImagingDevice">
+                    <Successors>
+                     <BeamPathNode Id="MTBLSM880ScannerDevice">
+                      <Successors>
+                       <BeamPathNode Id="MTBLaserModuleLKM980">
+                        <Successors>
+                         <BeamPathNode Id="MTBLSM880MbsInvis">
+                          <Successors>
+                           <BeamPathNode Id="MTBLSM880MbsVis">
+                            <Successors>
+                             <BeamPathNode Id="MTBLSM880BeamshiftCompensatorVis">
+                              <Successors>
+                               <BeamPathNode Id="MTBLSM880BeamshiftCompensatorVisYAxis">
+                                <Successors>
+                                 <BeamPathNode Id="MTBLSM880BeamshiftCompensatorVisXAxis">
+                                  <Successors>
+                                   <BeamPathNode Id="MTBLSM880BeamShaperWheelVis">
+                                    <Successors>
+                                     <BeamPathNode Id="MTBLSM880LaserCouplingVis">
+                                      <Successors>
+                                       <BeamPathNode Id="MTBLSM880ShutterVis">
+                                        <Successors>
+                                         <BeamPathNode Id="MTBLKM980Shutter445">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser445">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine445">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter488">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser488">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine488">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter514">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser514">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine514">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter543">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser543">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine543">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter561">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser561">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine561">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter594">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser594">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine594">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                         <BeamPathNode Id="MTBLKM980Shutter639">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980Laser639">
+                                            <Successors>
+                                             <BeamPathNode Id="MTBLKM980LaserLine639">
+                                              <Successors/>
+                                             </BeamPathNode>
+                                            </Successors>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                        </Successors>
+                                       </BeamPathNode>
+                                      </Successors>
+                                     </BeamPathNode>
+                                    </Successors>
+                                   </BeamPathNode>
+                                  </Successors>
+                                 </BeamPathNode>
+                                </Successors>
+                               </BeamPathNode>
+                              </Successors>
+                             </BeamPathNode>
+                            </Successors>
+                           </BeamPathNode>
+                           <BeamPathNode Id="MTBLSM880BeamshiftCompensatorInvis">
+                            <Successors>
+                             <BeamPathNode Id="MTBLSM880BeamshiftCompensatorInvisYAxis">
+                              <Successors>
+                               <BeamPathNode Id="MTBLSM880BeamshiftCompensatorInvisXAxis">
+                                <Successors>
+                                 <BeamPathNode Id="MTBLSM880BeamShaperWheelInvis">
+                                  <Successors>
+                                   <BeamPathNode Id="MTBLSM880LaserCouplingInvis">
+                                    <Successors>
+                                     <BeamPathNode Id="MTBLSM880ShutterInvis">
+                                      <Successors>
+                                       <BeamPathNode Id="MTBLSM880CollimatorInvis1">
+                                        <Successors>
+                                         <BeamPathNode Id="MTBLKM980Laser405">
+                                          <Successors>
+                                           <BeamPathNode Id="MTBLKM980LaserLine405">
+                                            <Successors/>
+                                           </BeamPathNode>
+                                          </Successors>
+                                         </BeamPathNode>
+                                        </Successors>
+                                       </BeamPathNode>
+                                       <BeamPathNode Id="MTBLKM980Laser730">
+                                        <Successors>
+                                         <BeamPathNode Id="MTBLKM980LaserLine730">
+                                          <Successors/>
+                                         </BeamPathNode>
+                                        </Successors>
+                                       </BeamPathNode>
+                                      </Successors>
+                                     </BeamPathNode>
+                                    </Successors>
+                                   </BeamPathNode>
+                                  </Successors>
+                                 </BeamPathNode>
+                                </Successors>
+                               </BeamPathNode>
+                              </Successors>
+                             </BeamPathNode>
+                            </Successors>
+                           </BeamPathNode>
+                          </Successors>
+                         </BeamPathNode>
+                        </Successors>
+                       </BeamPathNode>
+                      </Successors>
+                     </BeamPathNode>
+                    </Successors>
+                   </BeamPathNode>
+                  </Successors>
+                 </BeamPathNode>
+                </Successors>
+               </BeamPathNode>
+              </Successors>
+             </BeamPathNode>
+             <BeamPathNode Id="MTBRLShutter">
+              <Successors>
+               <BeamPathNode Id="AlbireoLEDController">
+                <Successors>
+                 <BeamPathNode Id="MTBLED1">
+                  <Successors/>
+                 </BeamPathNode>
+                 <BeamPathNode Id="MTBLED3">
+                  <Successors/>
+                 </BeamPathNode>
+                 <BeamPathNode Id="MTBLED5">
+                  <Successors/>
+                 </BeamPathNode>
+                 <BeamPathNode Id="MTBLED6">
+                  <Successors/>
+                 </BeamPathNode>
+                </Successors>
+               </BeamPathNode>
+              </Successors>
+             </BeamPathNode>
+            </Successors>
+           </BeamPathNode>
+          </Successors>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="TransmittedLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="Condenser">
+          <Successors>
+           <BeamPathNode Id="MTBCondenserContrastChanger">
+            <Successors>
+             <BeamPathNode Id="MTBTLApertureStop">
+              <Successors>
+               <BeamPathNode Id="MTBTLShutter">
+                <Successors>
+                 <BeamPathNode Id="MTBTLLampChanger">
+                  <Successors>
+                   <BeamPathNode Id="MTBTLHalogenLamp">
+                    <Successors/>
+                   </BeamPathNode>
+                  </Successors>
+                 </BeamPathNode>
+                </Successors>
+               </BeamPathNode>
+              </Successors>
+             </BeamPathNode>
+             <BeamPathNode Id="MTBLEDArraySF_FF">
+              <Successors/>
+             </BeamPathNode>
+            </Successors>
+           </BeamPathNode>
+          </Successors>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="ObliqueLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors/>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="PreviewLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="MTBObjectiveChanger">
+          <Successors>
+           <BeamPathNode Id="MTBCameraAdapter_Preview">
+            <Successors>
+             <BeamPathNode Id="MTBCamera_Preview.See3CAM_130">
+              <Successors/>
+             </BeamPathNode>
+            </Successors>
+           </BeamPathNode>
+          </Successors>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="PreviewReflectedLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="MTBObjectiveChanger">
+          <Successors>
+           <BeamPathNode Id="MTBLEDArraySF_RL">
+            <Successors/>
+           </BeamPathNode>
+          </Successors>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+      <BeamPath Key="PreviewTransmittedLightPath">
+       <BeamPathNode Id="MTBObject">
+        <Successors>
+         <BeamPathNode Id="MTBLEDArraySF_TL">
+          <Successors/>
+         </BeamPathNode>
+        </Successors>
+       </BeamPathNode>
+      </BeamPath>
+     </BeamPaths>
+    </Device>
+    <Device Id="MTBCameraAdapter_MTBSideportChanger_Right" Name="1x Camera Adapter" UniqueName="CameraAdapter.1xCSU" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <Magnification>1</Magnification>
+     <TotalAperture>0</TotalAperture>
+     <CameraId/>
+    </Device>
+    <Device Id="MTBCameraAdapter_Preview" Name="Preview Camera Adapter" UniqueName="CameraAdapterLeonardo.RL" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <Magnification>1</Magnification>
+     <TotalAperture>0</TotalAperture>
+     <CameraId/>
+    </Device>
+    <Device Id="MTBCondenserContrastChanger" Name="Condenser 0,55 mot f/ AI Sample Finder" UniqueName="Aquila.LEDArrayCondenser" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>7</MaxPosition>
+     <ChangerElements>
+      <Contrast Name="Bright Field" Id="" UniqueName="Contrast.BrightField" Model="" IsMounted="true" Position="1" Type="Contrast">
+       <ContrastMethods>BrightField</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <Contrast Name="PH1" Id="" UniqueName="Contrast.PH1" Model="" IsMounted="true" Position="2" Type="Contrast">
+       <ContrastMethods>PH1</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <Contrast Name="PH2" Id="" UniqueName="Contrast.PH2" Model="" IsMounted="true" Position="3" Type="Contrast">
+       <ContrastMethods>PH2</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <Contrast Name="PH3" Id="" UniqueName="Contrast.PH3" Model="" IsMounted="true" Position="4" Type="Contrast">
+       <ContrastMethods>PH3</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <Contrast Name="none" Id="" UniqueName="AquilaContrast.none" Model="" IsMounted="true" Position="5" Type="Contrast">
+       <ContrastMethods>BrightField</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <Contrast Name="none" Id="" UniqueName="AquilaContrast.none" Model="" IsMounted="true" Position="6" Type="Contrast">
+       <ContrastMethods>BrightField</ContrastMethods>
+       <PolarizingAngle>-1.7976931348623157E+308</PolarizingAngle>
+      </Contrast>
+      <ComponentID Name="SF LED" Id="" UniqueName="AquilaContrast.LEDArrayHolder" Model="" IsMounted="true" Position="7" Type="ComponentID">
+       <ComponentId>MTBLEDArraySF_FF</ComponentId>
+      </ComponentID>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBCondenserProperties" Name="Condenser properties" UniqueName="Aquila.Condenser_Properties" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274"/>
+    <Device Id="MTBEyePiece" Name="10x Eyepiece SF23" UniqueName="Eyepiece.10x_23" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="true" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <Magnification>10</Magnification>
+     <TotalAperture>0</TotalAperture>
+     <DepthOfField>0.30125526401036612</DepthOfField>
+     <FieldOfView>23</FieldOfView>
+     <TotalFieldOfView>0.36507936507936506</TotalFieldOfView>
+    </Device>
+    <Device Id="MTBFocus" Name="Motorized Focus" UniqueName="Aquila.Focus_mot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>-14000</MinPosition>
+     <MaxPosition>14000</MaxPosition>
+     <MaxDeviation>0.005</MaxDeviation>
+     <TypicalDeviation>0.005</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|nm|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-14000</Minimum>
+       <Maximum>14000</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>-25000000</Minimum>
+       <Maximum>25000000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>0.062</MinMoveSpeed>
+     <MaxMoveSpeed>6000</MaxMoveSpeed>
+     <SpeedUnit>µm/s</SpeedUnit>
+     <HasContinualSpeed>true</HasContinualSpeed>
+     <HasContinualStartSpeed>false</HasContinualStartSpeed>
+     <HasContinualAcceleration>true</HasContinualAcceleration>
+     <MinContinualSpeed>0.062</MinContinualSpeed>
+     <MaxContinualSpeed>6000</MaxContinualSpeed>
+     <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+     <MinContinualAcceleration>0</MinContinualAcceleration>
+     <MaxContinualAcceleration>10000</MaxContinualAcceleration>
+     <ContinualAccelerationUnit>µm/s²</ContinualAccelerationUnit>
+     <CoordinateDirection>1</CoordinateDirection>
+     <HasLoadWork>true</HasLoadWork>
+     <HasLowerSWLimit>true</HasLowerSWLimit>
+     <HasUpperSWLimit>true</HasUpperSWLimit>
+     <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+     <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+     <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+     <IsPositiveDirectionAgainstGravity>true</IsPositiveDirectionAgainstGravity>
+     <IsPositiveDirectionTowardSpecimen>true</IsPositiveDirectionTowardSpecimen>
+     <AvailableStageLoadLocations>Left, Center, Right</AvailableStageLoadLocations>
+    </Device>
+    <Device Id="MTBMicroscopeManager" Name="Microscope manager" UniqueName="Aquila.MicroscopeManager" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <ContrastManagerContrastMethods>0</ContrastManagerContrastMethods>
+     <ContrastManagerModes>Off, OnDemand, ContrastRetaining</ContrastManagerModes>
+     <LightManagerModes>Objective, Classic</LightManagerModes>
+     <UiControllerDialogs>Unknown</UiControllerDialogs>
+     <UiControllerPopups>Unknown</UiControllerPopups>
+     <IsCondenserFocusingAvailable>false</IsCondenserFocusingAvailable>
+     <IsCurrentFeedAvailable>false</IsCurrentFeedAvailable>
+     <IsDazzleProtectionAvailable>true</IsDazzleProtectionAvailable>
+     <IsLightManagerTemporaryAvailable>true</IsLightManagerTemporaryAvailable>
+     <IsParfocalCorrectionAvailable>true</IsParfocalCorrectionAvailable>
+     <IsParfocalCorrectionSilentModeOnOffAvailable>false</IsParfocalCorrectionSilentModeOnOffAvailable>
+     <IsParcentralCorrectionAvailable>true</IsParcentralCorrectionAvailable>
+     <IsParcentralCorrectionSilentModeOnOffAvailable>true</IsParcentralCorrectionSilentModeOnOffAvailable>
+     <IsParpolarizationCorrectionAvailable>false</IsParpolarizationCorrectionAvailable>
+     <IsParpolarizationCorrectionSilentModeOnOffAvailable>false</IsParpolarizationCorrectionSilentModeOnOffAvailable>
+     <IsLoadWorkCouplingOnOffAvailable>false</IsLoadWorkCouplingOnOffAvailable>
+     <IsVignettingFreeModeTemporaryAvailable>false</IsVignettingFreeModeTemporaryAvailable>
+     <IsLaserSafetyAvailable>false</IsLaserSafetyAvailable>
+     <SoftKeyCount>10</SoftKeyCount>
+     <HasSoftKeyLabeling>true</HasSoftKeyLabeling>
+     <HasUptimeRequest>true</HasUptimeRequest>
+     <IsObjectiveCorrFocusCorrectionAvailable>true</IsObjectiveCorrFocusCorrectionAvailable>
+    </Device>
+    <Device Id="MTBObject" Name="Object" UniqueName="Object" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274"/>
+    <Device Id="MTBObjectiveChanger" Name="6x Motorized Nosepiece" UniqueName="Aquila.Nosepiece_6xmot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>6</MaxPosition>
+     <ChangerElements>
+      <Objective Name="Plan-Apochromat 20x/0.8 M27" Id="" UniqueName="Objective.420650-9903-000" Model="" IsMounted="true" Position="1" Type="Objective">
+       <ContrastMethods>DIC2, BrightField, DarkField, RLBrightField, RLPol, TLPol</ContrastMethods>
+       <Features>Pol</Features>
+       <Immersions>Air</Immersions>
+       <Magnification>20</Magnification>
+       <NumericalAperture>0.8</NumericalAperture>
+       <WorkingDistance>610</WorkingDistance>
+       <TIRFAngleCorrection>0</TIRFAngleCorrection>
+      </Objective>
+      <Objective Name="Plan-Apochromat 63x/1.40 Oil DIC M27" Id="" UniqueName="Objective.420782-9900-799" Model="" IsMounted="true" Position="2" Type="Objective">
+       <ContrastMethods>DIC2, BrightField, DarkField, RLBrightField, RLPol, TLPol</ContrastMethods>
+       <Features>Pol, TIRF</Features>
+       <Immersions>Oil</Immersions>
+       <Magnification>63</Magnification>
+       <NumericalAperture>1.4</NumericalAperture>
+       <WorkingDistance>193</WorkingDistance>
+       <TIRFAngleCorrection>1</TIRFAngleCorrection>
+      </Objective>
+      <Objective Name="LD LCI Plan-Apochromat 40x/1.2 Imm Korr DIC M27" Id="" UniqueName="Objective.420862-9970-799" Model="" IsMounted="true" Position="3" Type="Objective">
+       <ContrastMethods>DIC3, BrightField, DarkField, RLBrightField, RLPol, TLPol</ContrastMethods>
+       <Features>Korr, Pol, LD, IR</Features>
+       <Immersions>Water</Immersions>
+       <Magnification>40</Magnification>
+       <NumericalAperture>1.2</NumericalAperture>
+       <WorkingDistance>410</WorkingDistance>
+       <TIRFAngleCorrection>0</TIRFAngleCorrection>
+      </Objective>
+      <Objective Name="EC Plan-Neofluar 10x/0.30 M27" Id="" UniqueName="Objective.420340-9901-000" Model="" IsMounted="true" Position="4" Type="Objective">
+       <ContrastMethods>DIC1, BrightField, DarkField, RLBrightField, RLPol, TLPol</ContrastMethods>
+       <Features>Pol</Features>
+       <Immersions>Air</Immersions>
+       <Magnification>10</Magnification>
+       <NumericalAperture>0.3</NumericalAperture>
+       <WorkingDistance>5300</WorkingDistance>
+       <TIRFAngleCorrection>0</TIRFAngleCorrection>
+      </Objective>
+      <BeamSplitter Name="Sample Finder Mirror" Id="" UniqueName="SampleFinderMirror.428400-9100-000" Model="" IsMounted="true" Position="5" Type="BeamSplitter">
+       <SplittingRatioSuccessor1>0.5</SplittingRatioSuccessor1>
+       <Successor1Id>MTBLEDArraySF_RL</Successor1Id>
+       <Successor2Id>MTBCameraPortSampleFinder</Successor2Id>
+      </BeamSplitter>
+      <Objective Name="none" Id="" UniqueName="Objective.none" Model="" IsMounted="false" Position="6" Type="Objective">
+       <ContrastMethods>Unknown</ContrastMethods>
+       <Features>Nothing</Features>
+       <Immersions>Unknown</Immersions>
+       <Magnification>0</Magnification>
+       <NumericalAperture>0</NumericalAperture>
+       <WorkingDistance>0</WorkingDistance>
+       <TIRFAngleCorrection>0</TIRFAngleCorrection>
+      </Objective>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBOptovarChanger" Name="3x Motorized Optovar Turret" UniqueName="Aquila.TubelensChanger_3xmot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>3</MaxPosition>
+     <ChangerElements>
+      <OptovarLens Name="1x Tubelens" Id="" UniqueName="Aquila.Tubelens 1.0x" Model="" IsMounted="true" Position="1" Type="Optovar">
+       <Magnification>1</Magnification>
+      </OptovarLens>
+      <ChangerElement Name="Tubelens LSM" Id="" UniqueName="Aquila.Tubelens LSM" Model="" IsMounted="false" Position="2" Type="None"/>
+      <ChangerElement Name="none" Id="" UniqueName="Aquila.Tubelens none" Model="" IsMounted="false" Position="3" Type="None"/>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBReflectorChanger" Name="6x Motorized Reflector Changer" UniqueName="Aquila.ReflectorChanger_6xmot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>6</MaxPosition>
+     <ChangerElements>
+      <ChangerElement Name="none" Id="" UniqueName="Reflector.none" Model="" IsMounted="false" Position="1" Type="None"/>
+      <ChangerElement Name="none" Id="" UniqueName="Reflector.none" Model="" IsMounted="false" Position="2" Type="None"/>
+      <ChangerElement Name="none" Id="" UniqueName="Reflector.none" Model="" IsMounted="false" Position="3" Type="None"/>
+      <ChangerElement Name="none" Id="" UniqueName="Reflector.none" Model="" IsMounted="false" Position="4" Type="None"/>
+      <Reflector Name="90 HE DAPI/ GFP/ Cy3 / Cy5" Id="" UniqueName="Reflector.489090-9100-000" Model="" IsMounted="true" Position="5" Type="Reflector">
+       <WavelengthAreas>
+        <WavelengthArea BeamSplitter="405" EmissionLow="410" EmissionHigh="440" ExcitationLow="370" ExcitationHigh="400"/>
+        <WavelengthArea BeamSplitter="493" EmissionLow="499" EmissionHigh="529" ExcitationLow="450" ExcitationHigh="488"/>
+        <WavelengthArea BeamSplitter="575" EmissionLow="579" EmissionHigh="604" ExcitationLow="540" ExcitationHigh="570"/>
+        <WavelengthArea BeamSplitter="653" EmissionLow="659" EmissionHigh="759" ExcitationLow="614" ExcitationHigh="647"/>
+       </WavelengthAreas>
+       <Features>HE</Features>
+      </Reflector>
+      <ChangerElement Name="none" Id="" UniqueName="Reflector.none" Model="" IsMounted="false" Position="6" Type="None"/>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBRLShutter" Name="RL Motorized Shutter" UniqueName="Aquila.RL_Shutter_mot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBRLTLSwitch" Name="RL/TL Switch" UniqueName="Aquila.RLTLSwitch" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <RLTLSwitchState Name="TL" Id="" UniqueName="RLTLSwitch.TL" Model="" IsMounted="true" Position="1" Type="RLTLSwitchState">
+       <LightPathLocation>TransmittedLight</LightPathLocation>
+      </RLTLSwitchState>
+      <RLTLSwitchState Name="RL" Id="" UniqueName="RLTLSwitch.RL" Model="" IsMounted="true" Position="2" Type="RLTLSwitchState">
+       <LightPathLocation>ReflectedLight</LightPathLocation>
+      </RLTLSwitchState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBSideportChanger" Name="3x Motorized Sideport Turret" UniqueName="Aquila.SideportChanger_3xmot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>3</MaxPosition>
+     <ChangerElements>
+      <Mirror Name="100% VIS" Id="" UniqueName="Aquila.SideportElement_100%BP" Model="" IsMounted="true" Position="1" Type="Mirror">
+       <SuccessorId>MTBEyePiece</SuccessorId>
+      </Mirror>
+      <Mirror Name="100% SP LSM" Id="" UniqueName="Aquila.SideportElement_100%LSM" Model="" IsMounted="true" Position="2" Type="Mirror">
+       <SuccessorId>MTBScanheadAdapter_Left</SuccessorId>
+      </Mirror>
+      <Mirror Name="100% R" Id="" UniqueName="Aquila.SideportElement_100%R" Model="" IsMounted="true" Position="3" Type="Mirror">
+       <SuccessorId>MTBCameraAdapter_MTBSideportChanger_Right</SuccessorId>
+      </Mirror>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBStage" Name="Motorized Stage (SMC2009)" UniqueName="Stage.SMC2009_int" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <StageAxes>
+      <StageAxis Name="x-Axis" Id="MTBStageAxisX" UniqueName="XAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+       <MinPosition>-350000</MinPosition>
+       <MaxPosition>350000</MaxPosition>
+       <MaxDeviation>4.875</MaxDeviation>
+       <TypicalDeviation>1.875</TypicalDeviation>
+       <StepWidth>0.25</StepWidth>
+       <PositionUnit>µm</PositionUnit>
+       <SupportedUnits>µm|</SupportedUnits>
+       <PositionRanges>
+        <Range Unit="µm">
+         <Minimum>-350000</Minimum>
+         <Maximum>350000</Maximum>
+        </Range>
+       </PositionRanges>
+       <MinMoveSpeed>0.001</MinMoveSpeed>
+       <MaxMoveSpeed>25000</MaxMoveSpeed>
+       <SpeedUnit>µm/s</SpeedUnit>
+       <HasContinualSpeed>true</HasContinualSpeed>
+       <HasContinualStartSpeed>false</HasContinualStartSpeed>
+       <HasContinualAcceleration>true</HasContinualAcceleration>
+       <MinContinualSpeed>0</MinContinualSpeed>
+       <MaxContinualSpeed>25000</MaxContinualSpeed>
+       <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+       <MinContinualAcceleration>0</MinContinualAcceleration>
+       <MaxContinualAcceleration>500000</MaxContinualAcceleration>
+       <ContinualAccelerationUnit>µm/s2</ContinualAccelerationUnit>
+       <CoordinateDirection>1</CoordinateDirection>
+       <HasLoadWork>false</HasLoadWork>
+       <HasLowerSWLimit>true</HasLowerSWLimit>
+       <HasUpperSWLimit>true</HasUpperSWLimit>
+       <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+       <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+       <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+      </StageAxis>
+      <StageAxis Name="y-Axis" Id="MTBStageAxisY" UniqueName="YAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+       <MinPosition>-350000</MinPosition>
+       <MaxPosition>350000</MaxPosition>
+       <MaxDeviation>4.875</MaxDeviation>
+       <TypicalDeviation>1.875</TypicalDeviation>
+       <StepWidth>0.25</StepWidth>
+       <PositionUnit>µm</PositionUnit>
+       <SupportedUnits>µm|</SupportedUnits>
+       <PositionRanges>
+        <Range Unit="µm">
+         <Minimum>-350000</Minimum>
+         <Maximum>350000</Maximum>
+        </Range>
+       </PositionRanges>
+       <MinMoveSpeed>0.001</MinMoveSpeed>
+       <MaxMoveSpeed>25000</MaxMoveSpeed>
+       <SpeedUnit>µm/s</SpeedUnit>
+       <HasContinualSpeed>true</HasContinualSpeed>
+       <HasContinualStartSpeed>false</HasContinualStartSpeed>
+       <HasContinualAcceleration>true</HasContinualAcceleration>
+       <MinContinualSpeed>0</MinContinualSpeed>
+       <MaxContinualSpeed>25000</MaxContinualSpeed>
+       <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+       <MinContinualAcceleration>0</MinContinualAcceleration>
+       <MaxContinualAcceleration>500000</MaxContinualAcceleration>
+       <ContinualAccelerationUnit>µm/s2</ContinualAccelerationUnit>
+       <CoordinateDirection>1</CoordinateDirection>
+       <HasLoadWork>false</HasLoadWork>
+       <HasLowerSWLimit>true</HasLowerSWLimit>
+       <HasUpperSWLimit>true</HasUpperSWLimit>
+       <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+       <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+       <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+      </StageAxis>
+     </StageAxes>
+    </Device>
+    <Device Id="MTBStageAxisX" Name="x-Axis" UniqueName="XAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>-350000</MinPosition>
+     <MaxPosition>350000</MaxPosition>
+     <MaxDeviation>4.875</MaxDeviation>
+     <TypicalDeviation>1.875</TypicalDeviation>
+     <StepWidth>0.25</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-350000</Minimum>
+       <Maximum>350000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>0.001</MinMoveSpeed>
+     <MaxMoveSpeed>25000</MaxMoveSpeed>
+     <SpeedUnit>µm/s</SpeedUnit>
+     <HasContinualSpeed>true</HasContinualSpeed>
+     <HasContinualStartSpeed>false</HasContinualStartSpeed>
+     <HasContinualAcceleration>true</HasContinualAcceleration>
+     <MinContinualSpeed>0</MinContinualSpeed>
+     <MaxContinualSpeed>25000</MaxContinualSpeed>
+     <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+     <MinContinualAcceleration>0</MinContinualAcceleration>
+     <MaxContinualAcceleration>500000</MaxContinualAcceleration>
+     <ContinualAccelerationUnit>µm/s2</ContinualAccelerationUnit>
+     <CoordinateDirection>1</CoordinateDirection>
+     <HasLoadWork>false</HasLoadWork>
+     <HasLowerSWLimit>true</HasLowerSWLimit>
+     <HasUpperSWLimit>true</HasUpperSWLimit>
+     <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+     <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+     <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+    </Device>
+    <Device Id="MTBStageAxisY" Name="y-Axis" UniqueName="YAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>-350000</MinPosition>
+     <MaxPosition>350000</MaxPosition>
+     <MaxDeviation>4.875</MaxDeviation>
+     <TypicalDeviation>1.875</TypicalDeviation>
+     <StepWidth>0.25</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-350000</Minimum>
+       <Maximum>350000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>0.001</MinMoveSpeed>
+     <MaxMoveSpeed>25000</MaxMoveSpeed>
+     <SpeedUnit>µm/s</SpeedUnit>
+     <HasContinualSpeed>true</HasContinualSpeed>
+     <HasContinualStartSpeed>false</HasContinualStartSpeed>
+     <HasContinualAcceleration>true</HasContinualAcceleration>
+     <MinContinualSpeed>0</MinContinualSpeed>
+     <MaxContinualSpeed>25000</MaxContinualSpeed>
+     <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+     <MinContinualAcceleration>0</MinContinualAcceleration>
+     <MaxContinualAcceleration>500000</MaxContinualAcceleration>
+     <ContinualAccelerationUnit>µm/s2</ContinualAccelerationUnit>
+     <CoordinateDirection>1</CoordinateDirection>
+     <HasLoadWork>false</HasLoadWork>
+     <HasLowerSWLimit>true</HasLowerSWLimit>
+     <HasUpperSWLimit>true</HasUpperSWLimit>
+     <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+     <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+     <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+    </Device>
+    <Device Id="MTBTLApertureStop" Name="Motorized Condenser Aperture" UniqueName="Aquila.Condenser_Aperture_mot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>0.09</MinPosition>
+     <MaxPosition>0.55</MaxPosition>
+     <MaxDeviation>0.00028785982478097627</MaxDeviation>
+     <TypicalDeviation>0.00028785982478097627</TypicalDeviation>
+     <StepWidth>0.00057571964956195255</StepWidth>
+     <PositionUnit>NA</PositionUnit>
+     <SupportedUnits>NA|mm|%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="NA">
+       <Minimum>0.09</Minimum>
+       <Maximum>0.55</Maximum>
+      </Range>
+      <Range Unit="mm">
+       <Minimum>3</Minimum>
+       <Maximum>36.5</Maximum>
+      </Range>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBTLHalogenLamp" Name="TL Halogen Lamp" UniqueName="Aquila.TL_HalogenLamp" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>12.2</MaxPosition>
+     <MaxDeviation>0.0059628543499511237</MaxDeviation>
+     <TypicalDeviation>0.0059628543499511237</TypicalDeviation>
+     <StepWidth>0.011925708699902247</StepWidth>
+     <PositionUnit>Volt</PositionUnit>
+     <SupportedUnits>%|Volt|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Volt">
+       <Minimum>0</Minimum>
+       <Maximum>12.2</Maximum>
+      </Range>
+     </PositionRanges>
+     <Has3200K>true</Has3200K>
+     <HasOnOff>true</HasOnOff>
+     <LampType>Halogen</LampType>
+    </Device>
+    <Device Id="MTBTLShutter" Name="TL Motorized Shutter" UniqueName="Aquila.TL_Shutter_mot" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLEDArraySF_TL" Name="AI Sample Finder Transmitted Light LED Array" UniqueName="MTBSampleFinder.LEDArrayTL" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="true" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>0</MaxPosition>
+     <MaxDeviation>0</MaxDeviation>
+     <TypicalDeviation>0</TypicalDeviation>
+     <StepWidth>0</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits/>
+     <PositionRanges/>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>LEDArray</LampType>
+     <NumberOfRows>8</NumberOfRows>
+     <NumberOfColumns>16</NumberOfColumns>
+     <MaxIntensity>100</MaxIntensity>
+     <MinIntensity>0</MinIntensity>
+     <MinSelectedLED>0</MinSelectedLED>
+     <MaxSelectedLED>0</MaxSelectedLED>
+     <SupportedContrastTypes/>
+     <SupportedContrastTypesBitmask>UserDefined|SLISD_Randomized|SLISD|</SupportedContrastTypesBitmask>
+     <SupportedProcessingModes/>
+    </Device>
+    <Device Id="MTBLEDArraySF_FF" Name="AI Sample Finder Focus Finder LED Array" UniqueName="MTBSampleFinder.LEDArrayFF" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="true" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>0</MaxPosition>
+     <MaxDeviation>0</MaxDeviation>
+     <TypicalDeviation>0</TypicalDeviation>
+     <StepWidth>0</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits/>
+     <PositionRanges/>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>LEDArray</LampType>
+     <NumberOfRows>1</NumberOfRows>
+     <NumberOfColumns>9</NumberOfColumns>
+     <MaxIntensity>100</MaxIntensity>
+     <MinIntensity>0</MinIntensity>
+     <MinSelectedLED>1</MinSelectedLED>
+     <MaxSelectedLED>4</MaxSelectedLED>
+     <SupportedContrastTypes>CentralLed|LedPair|</SupportedContrastTypes>
+     <SupportedContrastTypesBitmask/>
+     <SupportedProcessingModes/>
+    </Device>
+    <Device Id="MTBCondenserRLTempSensor" Name="Temperature Sensor " UniqueName="TestAquilaTemperature.ObjectiveTempSensor" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="02/25/2021" FirmwareName="Condenser Control" FirmwareVersion="03.009" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>80</MaxPosition>
+     <MaxDeviation>0.0055</MaxDeviation>
+     <TypicalDeviation>0.0025</TypicalDeviation>
+     <StepWidth>0.001</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>80</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLEDArraySF_RL" Name="AI Sample Finder Reflected Light LED Array" UniqueName="MTBSampleFinder.LEDArrayRL" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="true" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>0</MaxPosition>
+     <MaxDeviation>0</MaxDeviation>
+     <TypicalDeviation>0</TypicalDeviation>
+     <StepWidth>0</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits/>
+     <PositionRanges/>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>LEDArray</LampType>
+     <NumberOfRows>1</NumberOfRows>
+     <NumberOfColumns>12</NumberOfColumns>
+     <MaxIntensity>100</MaxIntensity>
+     <MinIntensity>0</MinIntensity>
+     <MinSelectedLED>1</MinSelectedLED>
+     <MaxSelectedLED>3</MaxSelectedLED>
+     <SupportedContrastTypes>LedPair|</SupportedContrastTypes>
+     <SupportedContrastTypesBitmask/>
+     <SupportedProcessingModes>None|Average|Minimum|</SupportedProcessingModes>
+    </Device>
+    <Device Id="MTBFocusStabilizer2" Name="Definite Focus 3" UniqueName="FocusStabilizer" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="10/07/2021" FirmwareName="DF2" FirmwareVersion="02.059" SerialNumber=""/>
+    <Device Id="MTBPiezoFocusCan" Name="Piezo Focus (WSB 500µm)" UniqueName="Piezofocus.WSB500" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="06/11/2019" FirmwareName="WSB ZPiezo CAN" FirmwareVersion="01.038" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>500</MaxPosition>
+     <MaxDeviation>0.10500000000000001</MaxDeviation>
+     <TypicalDeviation>0.055</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>0</Minimum>
+       <Maximum>500</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>0.3</MinMoveSpeed>
+     <MaxMoveSpeed>5000</MaxMoveSpeed>
+     <SpeedUnit>µm/s</SpeedUnit>
+     <HasContinualSpeed>true</HasContinualSpeed>
+     <HasContinualStartSpeed>false</HasContinualStartSpeed>
+     <HasContinualAcceleration>false</HasContinualAcceleration>
+     <MinContinualSpeed>0.3</MinContinualSpeed>
+     <MaxContinualSpeed>5000</MaxContinualSpeed>
+     <ContinualSpeedUnit>µm/s</ContinualSpeedUnit>
+     <CoordinateDirection>1</CoordinateDirection>
+     <HasLoadWork>false</HasLoadWork>
+     <HasLowerSWLimit>true</HasLowerSWLimit>
+     <HasUpperSWLimit>true</HasUpperSWLimit>
+     <IsAutomaticCalibrationSupported>true</IsAutomaticCalibrationSupported>
+     <IsManualCalibrationSupported>true</IsManualCalibrationSupported>
+     <HasHandwheelDeactivation>true</HasHandwheelDeactivation>
+     <IsPositiveDirectionAgainstGravity>false</IsPositiveDirectionAgainstGravity>
+     <IsPositiveDirectionTowardSpecimen>true</IsPositiveDirectionTowardSpecimen>
+     <AvailableStageLoadLocations>None</AvailableStageLoadLocations>
+     <HasAnalogControl>false</HasAnalogControl>
+     <RangeMax>0</RangeMax>
+     <RangePreciseMode>0</RangePreciseMode>
+    </Device>
+    <Device Id="MTBLSM880HealthStatus" Name="LSM 980 Health Status" UniqueName="LSM880.HealthStatus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035"/>
+    <Device Id="MTBLSM880InternalDetectors" Name="LSM880.InternalDetectors" UniqueName="LSM880.InternalDetectors" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035"/>
+    <Device Id="MTBSensorLogging" Name="LSM 980 Sensor Logging Handler" UniqueName="LSM880.SensorLoggingHandler" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035"/>
+    <Device Id="MTBLSM880ShutterInvis" Name="Main Shutter Invis" UniqueName="LSM880.MainPower.ShutterInvis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="2015/09/30" FirmwareName="MP-Master 742" FirmwareVersion="01.037" SerialNumber="145234  24  /V5">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880ShutterVis" Name="Main Shutter Vis" UniqueName="LSM880.MainPower.ShutterVis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="2015/09/30" FirmwareName="MP-Master 742" FirmwareVersion="01.037" SerialNumber="145234  24  /V5">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880SafetyControl710Laser543OnOff" Name="HeNe543 an/aus" UniqueName="LSM880.SafetyControl710.Laser543OnOff" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Laser.Off" Id="" UniqueName="Laser.Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Laser.On" Id="" UniqueName="Laser.On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880SafetyControl710Laser594OnOff" Name="HeNe594 an/aus" UniqueName="LSM880.SafetyControl710.Laser594OnOff" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Laser.Off" Id="" UniqueName="Laser.Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Laser.On" Id="" UniqueName="Laser.On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880SafetyControl710Laser633OnOff" Name="HeNe633 an/aus" UniqueName="LSM880.SafetyControl710.Laser633OnOff" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Laser.Off" Id="" UniqueName="Laser.Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Laser.On" Id="" UniqueName="Laser.On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880SafetyControl710PortExpander1" Name="PortExpander 1" UniqueName="LSM880.SafetyControl710.PortExpander1" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6"/>
+    <Device Id="MTBLSM880SafetyControl710PortExpander2" Name="PortExpander 2" UniqueName="LSM880.SafetyControl710.PortExpander2" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6"/>
+    <Device Id="MTBLSM880SafetyControl710PortExpander3" Name="PortExpander 3" UniqueName="LSM880.SafetyControl710.PortExpander3" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6"/>
+    <Device Id="MTBLSM880SafetyControl710PortExpander4" Name="PortExpander 4" UniqueName="LSM880.SafetyControl710.PortExpander4" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="23/09/09" FirmwareName="SafetyControl710" FirmwareVersion="02.251" SerialNumber="146387  47  /V6"/>
+    <Device Id="MTBLSM880MetaDiscriCoarseCh34DAC" Name="DiscriCoarse Ch34" UniqueName="LSM880.MetaDetector.DiscriCoarseCh34DAC" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>1</MaxPosition>
+     <MaxDeviation>0.00196078431372549</MaxDeviation>
+     <TypicalDeviation>0.00196078431372549</TypicalDeviation>
+     <StepWidth>0.00392156862745098</StepWidth>
+     <PositionUnit>V</PositionUnit>
+     <SupportedUnits>V|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="V">
+       <Minimum>0</Minimum>
+       <Maximum>1</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>0</Minimum>
+       <Maximum>255</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880MetaDiscriCoarseCh35DAC" Name="DiscriCoarse Ch35" UniqueName="LSM880.MetaDetector.DiscriCoarseCh35DAC" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>1</MaxPosition>
+     <MaxDeviation>0.00196078431372549</MaxDeviation>
+     <TypicalDeviation>0.00196078431372549</TypicalDeviation>
+     <StepWidth>0.00392156862745098</StepWidth>
+     <PositionUnit>V</PositionUnit>
+     <SupportedUnits>V|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="V">
+       <Minimum>0</Minimum>
+       <Maximum>1</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>0</Minimum>
+       <Maximum>255</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880MetaHvOverloadStatus" Name="LSM HV Overload Status" UniqueName="LSM880.MetaDetector.HvOverloadStatus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035"/>
+    <Device Id="MTBLSM880LaserCouplingInvis" Name="Invisible Light" UniqueName="LSM880.LaserCouplingInvis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber=""/>
+    <Device Id="MTBLSM880LaserCouplingVis" Name="Visible Light" UniqueName="LSM880.LaserCouplingVis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber=""/>
+    <Device Id="MTBLSM880MbsInvis" Name="Main Beam Splitter INVIS" UniqueName="LSM880.MbsInvis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>10</MaxPosition>
+     <ChangerElements>
+      <SpectralInfluencer Name="Plate" Id="" UniqueName="Beamsplitter.2412-295" Model="" IsMounted="true" Position="1" Type="SpectralInfluencer">
+       <OrderNumber>2412-295</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="2" Type="None"/>
+      <SpectralInfluencer Name="MBS -405" Id="" UniqueName="Beamsplitter.1520-117" Model="" IsMounted="true" Position="3" Type="SpectralInfluencer">
+       <OrderNumber>1520-117</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>405</High>
+         <Efficiency>0.99</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas/>
+      </SpectralInfluencer>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="4" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="5" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="6" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="7" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="8" Type="None"/>
+      <SpectralInfluencer Name="MBS T80/R20" Id="" UniqueName="Beamsplitter.2410-033" Model="" IsMounted="true" Position="9" Type="SpectralInfluencer">
+       <OrderNumber>2410-033</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0.2</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0.8</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="10" Type="None"/>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880MbsVis" Name="Main Beam Splitter VIS" UniqueName="LSM880.MbsVis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>10</MaxPosition>
+     <ChangerElements>
+      <SpectralInfluencer Name="MBS 488/561" Id="" UniqueName="Beamsplitter.2412-348" Model="" IsMounted="true" Position="1" Type="SpectralInfluencer">
+       <OrderNumber>2412-348</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>477</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>549</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>900</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="MBS 488/561/639" Id="" UniqueName="Beamsplitter.2412-349" Model="" IsMounted="true" Position="2" Type="SpectralInfluencer">
+       <OrderNumber>2412-349</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>477</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>549</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>619</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>659</Low>
+         <High>900</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="MBS 445/488/561/639" Id="" UniqueName="Beamsplitter.2440-816" Model="" IsMounted="true" Position="3" Type="SpectralInfluencer">
+       <OrderNumber>2440-816</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>438</Low>
+         <High>454</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>438</Low>
+         <High>454</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>562</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>429</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>463</Low>
+         <High>477</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>549</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>619</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>659</Low>
+         <High>900</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="MBS 488/639" Id="" UniqueName="Beamsplitter.2412-296" Model="" IsMounted="true" Position="4" Type="SpectralInfluencer">
+       <OrderNumber>2412-296</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.0001</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>487</Low>
+         <High>489</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>632</Low>
+         <High>646</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>477</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>619</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>659</Low>
+         <High>900</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="5" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="6" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="7" Type="None"/>
+      <ChangerElement Name="No Beamsplitter" Id="" UniqueName="Beamsplitter.none" Model="" IsMounted="false" Position="8" Type="None"/>
+      <SpectralInfluencer Name="MBS T80/R20" Id="" UniqueName="Beamsplitter.2410-033" Model="" IsMounted="true" Position="9" Type="SpectralInfluencer">
+       <OrderNumber>2410-033</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0.2</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0.8</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="Plate" Id="" UniqueName="Beamsplitter.2412-295" Model="" IsMounted="true" Position="10" Type="SpectralInfluencer">
+       <OrderNumber>2412-295</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880OneWire1PortExpander" Name="LSM Sensor Can85 PortExpander" UniqueName="LSM880.SensorCan85.PortExpander" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0126"/>
+    <Device Id="MTBLSM880OneWire1Sensor2" Name="LSM Sensor Can85 Temperature MPM" UniqueName="LSM880.SensorCan85.Sensor2" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0126">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.005</MaxDeviation>
+     <TypicalDeviation>0.005</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880OneWire1Sensor3" Name="LSM Sensor Can85 Temperature Grabber" UniqueName="LSM880.SensorCan85.Sensor3" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0126">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.005</MaxDeviation>
+     <TypicalDeviation>0.005</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880OneWire1Sensor4" Name="LSM Sensor Can85 Temperature Enclosure" UniqueName="LSM880.SensorCan85.Sensor4" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0126">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.005</MaxDeviation>
+     <TypicalDeviation>0.005</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880OneWire2PortExpander" Name="LSM Sensor Can86 PortExpander" UniqueName="LSM880.SensorCan86.PortExpander" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0079"/>
+    <Device Id="MTBLSM880OneWire2Sensor4" Name="LSM Sensor Can86 Temperature ScannerAmp" UniqueName="LSM880.SensorCan86.Sensor4" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/27/2013" FirmwareName="4-OneWire" FirmwareVersion="01.118" SerialNumber="22-02_143421_0079">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.005</MaxDeviation>
+     <TypicalDeviation>0.005</TypicalDeviation>
+     <StepWidth>0.01</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880MetaCh32PeltierOnOff" Name="Quasar Ch32 Peltier On/Off Switch" UniqueName="LSM880.Quasar36Ch.Ch32PeltierOnOffSwitch" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/04/2019" FirmwareName="TeCo-Kopf" FirmwareVersion="01.021" SerialNumber="145099  29 /V4">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Off" Id="" UniqueName="Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="On" Id="" UniqueName="On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880MetaCh32TargetTempPeltier" Name="Quasar Ch32 Peltier Target Temperature" UniqueName="LSM880.Quasar36Ch.Ch32TargetTempPeltier" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/04/2019" FirmwareName="TeCo-Kopf" FirmwareVersion="01.021" SerialNumber="145099  29 /V4">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>150</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>150</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880MetaCh34PeltierOnOff" Name="Quasar Ch34 Peltier On/Off Switch" UniqueName="LSM880.Quasar36Ch.Ch34PeltierOnOffSwitch" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/04/2019" FirmwareName="TeCo-Kopf" FirmwareVersion="01.021" SerialNumber="145099  29 /V4">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Off" Id="" UniqueName="Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="On" Id="" UniqueName="On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880MetaCh34TargetTempPeltier" Name="Quasar Ch34 Peltier Target Temperature" UniqueName="LSM880.Quasar36Ch.Ch34TargetTempPeltier" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/04/2019" FirmwareName="TeCo-Kopf" FirmwareVersion="01.021" SerialNumber="145099  29 /V4">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>150</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>150</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880ExternalDetectors" Name="LSM880.ExternalDetectors" UniqueName="LSM880.ExternalDetectors" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="145946  99  /V5"/>
+    <Device Id="MTBLSM880SRModule" Name="LSM880.SRModule" UniqueName="LSM880.SRModule" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-07_148972_00040"/>
+    <Device Id="MTBLSM880SRModulHealthStatus" Name="Airyscan health status" UniqueName="LSMSRModul.HealthStatus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-07_148972_00040"/>
+    <Device Id="MTBLSM880SRPeltierOnOff" Name="Airyscan Peltier On/Off Switch" UniqueName="LSMSR.Peltier.OnOffSwitch" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/15/2016" FirmwareName="SV-Peltier-HS" FirmwareVersion="01.127" SerialNumber="22-05_147694_0060">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Off" Id="" UniqueName="Off" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="On" Id="" UniqueName="On" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880SRTargetTempPeltier" Name="Airyscan Peltier Target Temperature" UniqueName="LSMSR.Peltier.TargetTemp" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/15/2016" FirmwareName="SV-Peltier-HS" FirmwareVersion="01.127" SerialNumber="22-05_147694_0060">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>150</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>150</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLSM880SRHvOverloadStatus" Name="Airyscan HV Overload Status" UniqueName="LSM.SR.HvOverloadStatus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-07_148972_00040"/>
+    <Device Id="AlbireoLEDController" Name="Colibri 5/7" UniqueName="Albireo.FLLEDController" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+     <HasTrigger>true</HasTrigger>
+     <LED1 Name="LED-Module 385nm    " Id="MTBLED1" UniqueName="AlbireoLED.423052-8303-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+      <MinPosition>0.1</MinPosition>
+      <MaxPosition>100</MaxPosition>
+      <MaxDeviation>0.05</MaxDeviation>
+      <TypicalDeviation>0.05</TypicalDeviation>
+      <StepWidth>0.1</StepWidth>
+      <PositionUnit>%</PositionUnit>
+      <SupportedUnits>%|</SupportedUnits>
+      <PositionRanges>
+       <Range Unit="%">
+        <Minimum>0.1</Minimum>
+        <Maximum>100</Maximum>
+       </Range>
+      </PositionRanges>
+      <Wavelength>385</Wavelength>
+      <FilterName>Exc 385/30</FilterName>
+      <FilterLow>370</FilterLow>
+      <FilterHigh>400</FilterHigh>
+     </LED1>
+     <LED2 Name="" Id="" UniqueName="" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+      <MinPosition>0</MinPosition>
+      <MaxPosition>0</MaxPosition>
+      <MaxDeviation>0</MaxDeviation>
+      <TypicalDeviation>0</TypicalDeviation>
+      <StepWidth>0</StepWidth>
+      <PositionUnit/>
+      <SupportedUnits/>
+      <PositionRanges/>
+      <Wavelength>0</Wavelength>
+      <FilterName/>
+      <FilterLow>0</FilterLow>
+      <FilterHigh>0</FilterHigh>
+     </LED2>
+     <LED3 Name="LED-Module 475nm    " Id="MTBLED3" UniqueName="AlbireoLED.423052-8302-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+      <MinPosition>0.1</MinPosition>
+      <MaxPosition>100</MaxPosition>
+      <MaxDeviation>0.05</MaxDeviation>
+      <TypicalDeviation>0.05</TypicalDeviation>
+      <StepWidth>0.1</StepWidth>
+      <PositionUnit>%</PositionUnit>
+      <SupportedUnits>%|</SupportedUnits>
+      <PositionRanges>
+       <Range Unit="%">
+        <Minimum>0.1</Minimum>
+        <Maximum>100</Maximum>
+       </Range>
+      </PositionRanges>
+      <Wavelength>475</Wavelength>
+      <FilterName>Exc 469/38</FilterName>
+      <FilterLow>450</FilterLow>
+      <FilterHigh>488</FilterHigh>
+     </LED3>
+     <LED4 Name="" Id="" UniqueName="" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+      <MinPosition>0</MinPosition>
+      <MaxPosition>0</MaxPosition>
+      <MaxDeviation>0</MaxDeviation>
+      <TypicalDeviation>0</TypicalDeviation>
+      <StepWidth>0</StepWidth>
+      <PositionUnit/>
+      <SupportedUnits/>
+      <PositionRanges/>
+      <Wavelength>0</Wavelength>
+      <FilterName/>
+      <FilterLow>0</FilterLow>
+      <FilterHigh>0</FilterHigh>
+     </LED4>
+     <LED5 Name="LED-Module 555nm    " Id="MTBLED5" UniqueName="AlbireoLED.423052-8307-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+      <MinPosition>0.1</MinPosition>
+      <MaxPosition>100</MaxPosition>
+      <MaxDeviation>0.05</MaxDeviation>
+      <TypicalDeviation>0.05</TypicalDeviation>
+      <StepWidth>0.1</StepWidth>
+      <PositionUnit>%</PositionUnit>
+      <SupportedUnits>%|</SupportedUnits>
+      <PositionRanges>
+       <Range Unit="%">
+        <Minimum>0.1</Minimum>
+        <Maximum>100</Maximum>
+       </Range>
+      </PositionRanges>
+      <Wavelength>555</Wavelength>
+      <FilterName>Exc 555/30</FilterName>
+      <FilterLow>540</FilterLow>
+      <FilterHigh>570</FilterHigh>
+     </LED5>
+     <LED6 Name="LED-Module 630nm    " Id="MTBLED6" UniqueName="AlbireoLED.423052-8300-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+      <MinPosition>0.1</MinPosition>
+      <MaxPosition>100</MaxPosition>
+      <MaxDeviation>0.05</MaxDeviation>
+      <TypicalDeviation>0.05</TypicalDeviation>
+      <StepWidth>0.1</StepWidth>
+      <PositionUnit>%</PositionUnit>
+      <SupportedUnits>%|</SupportedUnits>
+      <PositionRanges>
+       <Range Unit="%">
+        <Minimum>0.1</Minimum>
+        <Maximum>100</Maximum>
+       </Range>
+      </PositionRanges>
+      <Wavelength>630</Wavelength>
+      <FilterName>Exc 631/33</FilterName>
+      <FilterLow>615</FilterLow>
+      <FilterHigh>648</FilterHigh>
+     </LED6>
+     <FilterChanger Name="" Id="" UniqueName="" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+      <MinPosition>-1</MinPosition>
+      <MaxPosition>-1</MaxPosition>
+      <ChangerElements/>
+     </FilterChanger>
+    </Device>
+    <Device Id="MTBLED1" Name="LED-Module 385nm    " UniqueName="AlbireoLED.423052-8303-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+     <MinPosition>0.1</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.1</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+     <Wavelength>385</Wavelength>
+     <FilterName>Exc 385/30</FilterName>
+     <FilterLow>370</FilterLow>
+     <FilterHigh>400</FilterHigh>
+    </Device>
+    <Device Id="MTBLED3" Name="LED-Module 475nm    " UniqueName="AlbireoLED.423052-8302-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+     <MinPosition>0.1</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.1</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+     <Wavelength>475</Wavelength>
+     <FilterName>Exc 469/38</FilterName>
+     <FilterLow>450</FilterLow>
+     <FilterHigh>488</FilterHigh>
+    </Device>
+    <Device Id="MTBLED5" Name="LED-Module 555nm    " UniqueName="AlbireoLED.423052-8307-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+     <MinPosition>0.1</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.1</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+     <Wavelength>555</Wavelength>
+     <FilterName>Exc 555/30</FilterName>
+     <FilterLow>540</FilterLow>
+     <FilterHigh>570</FilterHigh>
+    </Device>
+    <Device Id="MTBLED6" Name="LED-Module 630nm    " UniqueName="AlbireoLED.423052-8300-000" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="03/31/2022" FirmwareName="ALB_Control" FirmwareVersion="02.222" SerialNumber="">
+     <MinPosition>0.1</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.05</MaxDeviation>
+     <TypicalDeviation>0.05</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.1</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+     <Wavelength>630</Wavelength>
+     <FilterName>Exc 631/33</FilterName>
+     <FilterLow>615</FilterLow>
+     <FilterHigh>648</FilterHigh>
+    </Device>
+    <Device Id="MTBTLLampChanger" Name="LSM Transmission Mirror" UniqueName="LSM880.TransmissionMirror" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="05/23/2011" FirmwareName="USS-Applikation" FirmwareVersion="01.102" SerialNumber="146331  9  /V4">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <Mirror Name="left" Id="" UniqueName="Mirror.Left" Model="" IsMounted="true" Position="1" Type="Mirror">
+       <SuccessorId>MTBTLLampChangerPortLeft</SuccessorId>
+      </Mirror>
+      <Mirror Name="TL Halogen Lamp" Id="" UniqueName="Mirror.Right" Model="" IsMounted="true" Position="2" Type="Mirror">
+       <SuccessorId>MTBTLHalogenLamp</SuccessorId>
+      </Mirror>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLaserModuleLKM980HealthStatus" Name="LKM health status" UniqueName="LaserModuleLKM980.HealthStatus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02"/>
+    <Device Id="MTBLKM980Mainboard" Name="LKM980.MainBoard" UniqueName="LKM980.MainBoard" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Manual" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02"/>
+    <Device Id="MTBLKM980Shutter445" Name="Shutter 445" UniqueName="LaserModuleLKM980.Shutter445" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Shutter488" Name="Shutter 488" UniqueName="LaserModuleLKM980.Shutter488" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Shutter514" Name="Shutter 514" UniqueName="LaserModuleLKM980.Shutter514" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Shutter561" Name="Shutter 561" UniqueName="LaserModuleLKM980.Shutter561" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Shutter594" Name="Shutter 594" UniqueName="LaserModuleLKM980.Shutter594" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Shutter639" Name="Shutter 639" UniqueName="LaserModuleLKM980.Shutter639" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>2</MaxPosition>
+     <ChangerElements>
+      <ShutterState Name="Closed" Id="" UniqueName="Shutter.Closed" Model="" IsMounted="true" Position="1" Type="ShutterState">
+       <IsOpen>false</IsOpen>
+      </ShutterState>
+      <ShutterState Name="Open" Id="" UniqueName="Shutter.Open" Model="" IsMounted="true" Position="2" Type="ShutterState">
+       <IsOpen>true</IsOpen>
+      </ShutterState>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLKM980Laser561WarmupProgress" Name="Laserrack Laser561 Warmup Progress" UniqueName="Laserrack980.Laser561.WarmupProgress" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.5</MaxDeviation>
+     <TypicalDeviation>0.5</TypicalDeviation>
+     <StepWidth>1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLKM980MonitordiodeInternValue" Name="LKM980.MonitordiodeIntern.Value" UniqueName="LKM980.MonitordiodeIntern.Value" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/23/2018" FirmwareName="MonitorDiode" FirmwareVersion="01.012" SerialNumber="000000-2307-861/V01">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>256.8775395</MaxPosition>
+     <MaxDeviation>0.00195985</MaxDeviation>
+     <TypicalDeviation>0.00195985</TypicalDeviation>
+     <StepWidth>0.0039197</StepWidth>
+     <PositionUnit>dBr</PositionUnit>
+     <SupportedUnits>dBr|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="dBr">
+       <Minimum>0</Minimum>
+       <Maximum>256.8775395</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBLKM980MonitordiodeExternValue" Name="LKM980.MonitordiodeExtern.Value" UniqueName="LKM980.MonitordiodeExtern.Value" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="11/23/2018" FirmwareName="MonitorDiode" FirmwareVersion="01.012" SerialNumber="000000-2307-861/V01">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>256.8775395</MaxPosition>
+     <MaxDeviation>0.00195985</MaxDeviation>
+     <TypicalDeviation>0.00195985</TypicalDeviation>
+     <StepWidth>0.0039197</StepWidth>
+     <PositionUnit>dBr</PositionUnit>
+     <SupportedUnits>dBr|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="dBr">
+       <Minimum>0</Minimum>
+       <Maximum>256.8775395</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBOverallSafety" Name="Overall Safety" UniqueName="Safety.OverallSafety" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/02/2020" FirmwareName="AQU_SafetyController" FirmwareVersion="03.101" SerialNumber=""/>
+    <Device Id="MTBIncubationCalibrationSensor" Name="Control Sensor T" UniqueName="IncubationPeCon.CalibrationSensor" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="03/15/2012" FirmwareName="PeCon_DevHeater" FirmwareVersion="01.120" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>99.9</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>99.9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBIncubationTemperatureChannel1" Name="H Insert P" UniqueName="IncubationPeCon.TempChannel1" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/15/2012" FirmwareName="PeCon_DevHeater" FirmwareVersion="01.120" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>99.9</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>99.9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBIncubationTemperatureChannel2" Name="None" UniqueName="IncubationPeCon.TempChannel2" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/15/2012" FirmwareName="PeCon_DevHeater" FirmwareVersion="01.120" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>99.9</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>99.9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBIncubationTemperatureChannel3" Name="H Unit XL" UniqueName="IncubationPeCon.TempChannel3" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/15/2012" FirmwareName="PeCon_DevHeater" FirmwareVersion="01.120" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>99.9</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>99.9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBIncubationTemperatureChannel4" Name="H Dev Humid" UniqueName="IncubationPeCon.TempChannel4" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/15/2012" FirmwareName="PeCon_DevHeater" FirmwareVersion="01.120" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>99.9</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>0</Minimum>
+       <Maximum>99.9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBIncubationCO2Channel" Name="CO2 Small V" UniqueName="IncubationPeCon.CO2Channel" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="10/02/2013" FirmwareName="PeCon_CO2" FirmwareVersion="01.004" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>20</MaxPosition>
+     <MaxDeviation>0.15000000000000002</MaxDeviation>
+     <TypicalDeviation>0.15000000000000002</TypicalDeviation>
+     <StepWidth>0.1</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>20</Maximum>
+      </Range>
+     </PositionRanges>
+     <Saturation>None</Saturation>
+    </Device>
+    <Device Id="MTBIncubationCO2Fan" Name="CO2-Fan" UniqueName="IncubationPeCon.CO2Fan" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="10/02/2013" FirmwareName="PeCon_CO2" FirmwareVersion="01.004" SerialNumber="">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>9</MaxPosition>
+     <MaxDeviation>0.5</MaxDeviation>
+     <TypicalDeviation>0.5</TypicalDeviation>
+     <StepWidth>1</StepWidth>
+     <PositionUnit>Level</PositionUnit>
+     <SupportedUnits>Level|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="Level">
+       <Minimum>0</Minimum>
+       <Maximum>9</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBMicoIFHSTemperature" Name="MicoIFHS Temperature" UniqueName="MicoIFHS.Temperature" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Coded" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="MicoIF HS" FirmwareVersion="" SerialNumber="">
+     <MinPosition>-30</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.5</MaxDeviation>
+     <TypicalDeviation>0.5</TypicalDeviation>
+     <StepWidth>1</StepWidth>
+     <PositionUnit>°C</PositionUnit>
+     <SupportedUnits>°C|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="°C">
+       <Minimum>-30</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+     </PositionRanges>
+    </Device>
+    <Device Id="MTBRTRtNotification" Name="RtNotificationHandler" UniqueName="RtNotificationHandler" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="MicoIF HS" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="MTBCamera_Preview.See3CAM_130" Name="PreviewCamera" UniqueName="See3CAM_130_20084A06" Model="See3CAM_130" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="true" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" IsVisibleInGUI="false" NeedsExperimentStateChange="false"/>
+    <Device Id="MTBCamera_MTBSideportChanger_Right.Axiocam705m" Name="Axiocam 705 mono" UniqueName="Axiocam705m_S843" Model="Axiocam705m" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="true" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" IsVisibleInGUI="true" NeedsExperimentStateChange="false"/>
+    <Device Id="SoftwareAutofocus" Name="SoftwareAutofocus" UniqueName="SoftwareAutofocus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="Autofocus" Name="Autofocus" UniqueName="Autofocus" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="Incubation" Name="Incubation" UniqueName="Incubation" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="IOCard" Name="IOCard" UniqueName="IOCard" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+     <DigitalInLabels>
+      <DigitalInLabel Label="Trigger In 1"/>
+      <DigitalInLabel Label="Trigger In 2"/>
+      <DigitalInLabel Label="Trigger In 3"/>
+      <DigitalInLabel Label="Trigger In 4"/>
+     </DigitalInLabels>
+     <DigitalOutLabels>
+      <DigitalOutLabel Label="Trigger Out 1"/>
+      <DigitalOutLabel Label="Trigger Out 2"/>
+      <DigitalOutLabel Label="Trigger Out 3"/>
+      <DigitalOutLabel Label="Trigger Out 4"/>
+     </DigitalOutLabels>
+     <AnalogInLabels/>
+     <AnalogOutLabels/>
+     <AnalogOutMinimums/>
+     <AnalogOutMaximums/>
+    </Device>
+    <Device Id="MTBScanheadAdapter_Left" Name="1x Scanhead Adapter (LSM)" UniqueName="ScanheadAdapter.1x (LSM)" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="01/13/2022" FirmwareName="AQU_MasterControl" FirmwareVersion="02.717" SerialNumber="03711274">
+     <Magnification>1</Magnification>
+     <TotalAperture>0</TotalAperture>
+     <CameraId/>
+     <FocalLength>150</FocalLength>
+    </Device>
+    <Device Id="MTBLSM880InternalDetectorsMirror" Name="MTBLSM880InternalDetectorsMirror" UniqueName="MTBLSM880InternalDetectorsMirror" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="MTBLSM880ReadbackDetectorX" Name="" UniqueName="MTBLSM880ReadbackDetectorX" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" MinDigGain="0" MaxDigGain="0" MinInputHVValue="0" MaxInputHVValue="0" HasOffValue="false" HasDigitalAmplifier="false" OffValue="0" DetectionChannelCount="0" HasOverloadDetection="false" DigiGainFactorLambda="0" DigiGainFactorChannel="0" NumberInDetectorGroup="0" PipelineDelay="4" MaximumPhotonCountingFrequency="0" WavelengthLow="0" WavelengthHigh="0">
+     <DetectorUsage>Unknown</DetectorUsage>
+     <DetectorTechnology>Unknown</DetectorTechnology>
+     <DetectorFeatures>None</DetectorFeatures>
+    </Device>
+    <Device Id="MTBLSM880ReadbackDetectorY" Name="" UniqueName="MTBLSM880ReadbackDetectorY" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" MinDigGain="0" MaxDigGain="0" MinInputHVValue="0" MaxInputHVValue="0" HasOffValue="false" HasDigitalAmplifier="false" OffValue="0" DetectionChannelCount="0" HasOverloadDetection="false" DigiGainFactorLambda="0" DigiGainFactorChannel="0" NumberInDetectorGroup="0" PipelineDelay="4" MaximumPhotonCountingFrequency="0" WavelengthLow="0" WavelengthHigh="0">
+     <DetectorUsage>Unknown</DetectorUsage>
+     <DetectorTechnology>Unknown</DetectorTechnology>
+     <DetectorFeatures>None</DetectorFeatures>
+    </Device>
+    <Device Id="MTBLSM880ScannerDevice" Name="MTBLSM880ScannerDevice" UniqueName="MTBLSM880ScannerDevice" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" ScannerXAxisId="MTBLSM880ScannerX" ScannerYAxisId="MTBLSM880ScannerY" ScannerZAxisId="MTBLSM880ScannerZ" FocalLength="52.5" ImageFlip="ExchangeXY, MirrorX, MirrorY">
+     <ScanFieldDacRange>-0.95,-0.95,1.9,1.9</ScanFieldDacRange>
+    </Device>
+    <Device Id="MTBLSM880ScannerX" Name="LSM880.ScannerX" UniqueName="MTBLSM880ScannerX" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" ReadBackDetectorID="MTBLSM880ReadbackDetectorX">
+     <ReadBackSignalFactor>1</ReadBackSignalFactor>
+     <ReadBackSignalOffset>0</ReadBackSignalOffset>
+     <ParkPosition>0</ParkPosition>
+     <AmplitudeAtZoom1>0.45434824813</AmplitudeAtZoom1>
+     <ScanWidthAtZoom1>0.0084853</ScanWidthAtZoom1>
+     <ErrorDigiPotId>RDAC1103</ErrorDigiPotId>
+     <GainDigiPotId>RDAC1104</GainDigiPotId>
+     <OffsetDigiPotId>RDAC1105</OffsetDigiPotId>
+     <PositionDigiPotId>RDAC1102</PositionDigiPotId>
+     <VelocityDigiPotId>RDAC1101</VelocityDigiPotId>
+     <PixelDelaySynthesis>1.5</PixelDelaySynthesis>
+     <PixelDelayReadback>0</PixelDelayReadback>
+     <MaximumAmplitude>0.95</MaximumAmplitude>
+     <MaxDacRangeVelocity>2271</MaxDacRangeVelocity>
+     <MaxDacRangeAcceleration>48400000</MaxDacRangeAcceleration>
+     <FastAiryscanSpeedIndices>1;2;3;4;5;6;7;8;9;10;11;12;14</FastAiryscanSpeedIndices>
+     <MinimumZoomLevels>
+      <Key>1</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>2</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>3</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>4</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>5</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>6</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>7</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>8</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>9</Key>
+      <Value>0.71103927203065143</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>10</Key>
+      <Value>1.099320465553387</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>11</Key>
+      <Value>1.3594985875706218</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>12</Key>
+      <Value>1.7708783068783069</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>14</Key>
+      <Value>3.2550505870259157</Value>
+     </MinimumZoomLevels>
+    </Device>
+    <Device Id="MTBLSM880ScannerY" Name="LSM880.ScannerY" UniqueName="MTBLSM880ScannerY" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" ReadBackDetectorID="MTBLSM880ReadbackDetectorY">
+     <ReadBackSignalFactor>1</ReadBackSignalFactor>
+     <ReadBackSignalOffset>0</ReadBackSignalOffset>
+     <ParkPosition>0</ParkPosition>
+     <AmplitudeAtZoom1>0.45434824813</AmplitudeAtZoom1>
+     <ScanWidthAtZoom1>0.0084853</ScanWidthAtZoom1>
+     <ErrorDigiPotId>RDAC1109</ErrorDigiPotId>
+     <GainDigiPotId>RDAC1110</GainDigiPotId>
+     <OffsetDigiPotId>RDAC1111</OffsetDigiPotId>
+     <PositionDigiPotId>RDAC1108</PositionDigiPotId>
+     <VelocityDigiPotId>RDAC1107</VelocityDigiPotId>
+     <PixelDelaySynthesis>1.5</PixelDelaySynthesis>
+     <PixelDelayReadback>0</PixelDelayReadback>
+     <MaximumAmplitude>0.95</MaximumAmplitude>
+     <MaxDacRangeVelocity>2271</MaxDacRangeVelocity>
+     <MaxDacRangeAcceleration>48400000</MaxDacRangeAcceleration>
+     <FastAiryscanSpeedIndices>1;2;3;4;5;6;7;8;9;10;11;12;14</FastAiryscanSpeedIndices>
+     <MinimumZoomLevels>
+      <Key>1</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>2</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>3</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>4</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>5</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>6</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>7</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>8</Key>
+      <Value>0.6</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>9</Key>
+      <Value>0.71103927203065143</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>10</Key>
+      <Value>1.099320465553387</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>11</Key>
+      <Value>1.3594985875706218</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>12</Key>
+      <Value>1.7708783068783069</Value>
+     </MinimumZoomLevels>
+     <MinimumZoomLevels>
+      <Key>14</Key>
+      <Value>3.2550505870259157</Value>
+     </MinimumZoomLevels>
+    </Device>
+    <Device Id="MTBLSM880ScannerZ" Name="LSM880.ScannerZ" UniqueName="MTBLSM880ScannerZ" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" ReadBackDetectorID="">
+     <ReadBackSignalFactor>1</ReadBackSignalFactor>
+     <ReadBackSignalOffset>0</ReadBackSignalOffset>
+     <ParkPosition>0</ParkPosition>
+     <AmplitudeAtZoom1>0.45434824813</AmplitudeAtZoom1>
+     <ScanWidthAtZoom1>0.0084853</ScanWidthAtZoom1>
+     <ErrorDigiPotId/>
+     <GainDigiPotId/>
+     <OffsetDigiPotId/>
+     <PositionDigiPotId/>
+     <VelocityDigiPotId/>
+     <PixelDelaySynthesis>0</PixelDelaySynthesis>
+     <PixelDelayReadback>0</PixelDelayReadback>
+     <MaximumAmplitude>0.95</MaximumAmplitude>
+     <MaxDacRangeVelocity>2271</MaxDacRangeVelocity>
+     <MaxDacRangeAcceleration>48400000</MaxDacRangeAcceleration>
+     <FastAiryscanSpeedIndices/>
+    </Device>
+    <Device Id="MTBLSM880BeamshiftCompensatorVisXAxis" Name="LSM BeamshiftCompensator Vis X Axis" UniqueName="LSM880.BeamshiftCompensator.Vis.XAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  624  /V4">
+     <MinPosition>-573.85</MinPosition>
+     <MaxPosition>575</MaxPosition>
+     <MaxDeviation>0.575</MaxDeviation>
+     <TypicalDeviation>0.575</TypicalDeviation>
+     <StepWidth>1.15</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-573.85</Minimum>
+       <Maximum>575</Maximum>
+      </Range>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880BeamshiftCompensatorVisYAxis" Name="LSM BeamshiftCompensator Vis Y Axis" UniqueName="LSM880.BeamshiftCompensator.Vis.YAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  624  /V4">
+     <MinPosition>-688.62</MinPosition>
+     <MaxPosition>690</MaxPosition>
+     <MaxDeviation>0.69</MaxDeviation>
+     <TypicalDeviation>0.69</TypicalDeviation>
+     <StepWidth>1.38</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-688.62</Minimum>
+       <Maximum>690</Maximum>
+      </Range>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880PinholeDiameterCollimatingLens" Name="Pinhole Collimating Lens" UniqueName="MTBLSM880PinholeDiameterCollimatingLens" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" FocalLength="47.395"/>
+    <Device Id="MTBLSM880PinholeDiameter" Name="LSM Pinhole Diameter" UniqueName="LSM880.Pinhole.Diameter" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="145946  82  /V5" FocalLength="100">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>708.78446922835712</MaxPosition>
+     <MaxDeviation>0.94253253886749622</MaxDeviation>
+     <TypicalDeviation>0.94253253886749622</TypicalDeviation>
+     <StepWidth>1.8850650777349924</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>%|µm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="µm">
+       <Minimum>0</Minimum>
+       <Maximum>708.78446922835712</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>460</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880BeamshiftCompensatorInvisXAxis" Name="LSM BeamshiftCompensator Invis X Axis" UniqueName="LSM880.BeamshiftCompensator.Invis.XAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  647  /V4">
+     <MinPosition>-573.85</MinPosition>
+     <MaxPosition>575</MaxPosition>
+     <MaxDeviation>0.575</MaxDeviation>
+     <TypicalDeviation>0.575</TypicalDeviation>
+     <StepWidth>1.15</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-573.85</Minimum>
+       <Maximum>575</Maximum>
+      </Range>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880BeamshiftCompensatorInvisYAxis" Name="LSM BeamshiftCompensator Invis Y Axis" UniqueName="LSM880.BeamshiftCompensator.Invis.YAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  647  /V4">
+     <MinPosition>-688.62</MinPosition>
+     <MaxPosition>690</MaxPosition>
+     <MaxDeviation>0.69</MaxDeviation>
+     <TypicalDeviation>0.69</TypicalDeviation>
+     <StepWidth>1.38</StepWidth>
+     <PositionUnit>µm</PositionUnit>
+     <SupportedUnits>µm|%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="µm">
+       <Minimum>-688.62</Minimum>
+       <Maximum>690</Maximum>
+      </Range>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880DetectorLong" Name="MA-Pmt2" UniqueName="MTBLSM880DetectorLong" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035" MinDigGain="0.3" MaxDigGain="15" MinInputHVValue="0" MaxInputHVValue="1250" HasOffValue="false" HasDigitalAmplifier="true" OffValue="0" DetectionChannelCount="1" HasOverloadDetection="true" DigiGainFactorLambda="1" DigiGainFactorChannel="1" NumberInDetectorGroup="2" PipelineDelay="2" EnableHvSwitchId="LSM_HS_HVRelais" MaximumPhotonCountingFrequency="0" WavelengthLow="200" WavelengthHigh="900">
+     <DetectorUsage>SingleChannel</DetectorUsage>
+     <DetectorTechnology>MultiAlkali</DetectorTechnology>
+     <DetectorFeatures>Integration</DetectorFeatures>
+    </Device>
+    <Device Id="MTBLSM880DetectorShort" Name="MA-Pmt1" UniqueName="MTBLSM880DetectorShort" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035" MinDigGain="0.3" MaxDigGain="15" MinInputHVValue="0" MaxInputHVValue="1250" HasOffValue="false" HasDigitalAmplifier="true" OffValue="0" DetectionChannelCount="1" HasOverloadDetection="true" DigiGainFactorLambda="1" DigiGainFactorChannel="1" NumberInDetectorGroup="1" PipelineDelay="2" EnableHvSwitchId="LSM_HS_HVRelais" MaximumPhotonCountingFrequency="0" WavelengthLow="200" WavelengthHigh="900">
+     <DetectorUsage>SingleChannel</DetectorUsage>
+     <DetectorTechnology>MultiAlkali</DetectorTechnology>
+     <DetectorFeatures>Integration</DetectorFeatures>
+    </Device>
+    <Device Id="MTBLSM880CollimatorInvis1" Name="Collimator Invis 1" UniqueName="LSM880.Collimator.Invis1" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  552  /V4">
+     <MinPosition>-1.3625000000000003</MinPosition>
+     <MaxPosition>0.74531249999999982</MaxPosition>
+     <MaxDeviation>0.00078125</MaxDeviation>
+     <TypicalDeviation>0.00078125</TypicalDeviation>
+     <StepWidth>0.0015625</StepWidth>
+     <PositionUnit>mm</PositionUnit>
+     <SupportedUnits>%|mm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="mm">
+       <Minimum>-1.3625000000000003</Minimum>
+       <Maximum>0.74531249999999982</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1350</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+     <DefaultPosition>836</DefaultPosition>
+     <TransmissionRatio>0.0015625</TransmissionRatio>
+    </Device>
+    <Device Id="MTBLSM880SRMetaDetector" Name="Airyscan" UniqueName="MTBLSM880SRMetaDetector" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-07_148972_00040" MinDigGain="0.3" MaxDigGain="15" MinInputHVValue="500" MaxInputHVValue="1000" HasOffValue="true" HasDigitalAmplifier="true" OffValue="0" DetectionChannelCount="32" HasOverloadDetection="true" DigiGainFactorLambda="1.5" DigiGainFactorChannel="1.5" NumberInDetectorGroup="0" PipelineDelay="0" EnableHvSwitchId="MetaHvRelais" MaximumPhotonCountingFrequency="0" WavelengthLow="300" WavelengthHigh="735">
+     <DetectorUsage>Airyscan</DetectorUsage>
+     <DetectorTechnology>GaAsP</DetectorTechnology>
+     <DetectorFeatures>Binning, Integration</DetectorFeatures>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+    </Device>
+    <Device Id="MTBLSM880PinholeSR" Name="Airyscan Pinhole" UniqueName="MTBLSM880PinholeSR" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" XAxisId="MTBLSM880PinholeSRXAxis" YAxisId="MTBLSM880PinholeSRYAxis" FocalLength="157" AiryScanMagnificationAt1XObjective="2.4909109120879869"/>
+    <Device Id="MTBLSM880PinholeSRXAxis" Name="LSM Airyscan Pinhole X Axis" UniqueName="LSM880.SR.XAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/15/2020" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.108" SerialNumber="22-04_147434_0477">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.050050050050050053</MaxDeviation>
+     <TypicalDeviation>0.050050050050050053</TypicalDeviation>
+     <StepWidth>0.10010010010010011</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|µrad|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="µrad">
+       <Minimum>-5988</Minimum>
+       <Maximum>6000</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880PinholeSRYAxis" Name="LSM Airyscan Pinhole Y Axis" UniqueName="LSM880.SR.YAxis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/15/2020" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.108" SerialNumber="22-04_147434_0477">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.050050050050050053</MaxDeviation>
+     <TypicalDeviation>0.050050050050050053</TypicalDeviation>
+     <StepWidth>0.10010010010010011</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|µrad|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="µrad">
+       <Minimum>-7000</Minimum>
+       <Maximum>6986</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880EmissionFilterSR" Name="EmissionFilter SR" UniqueName="LSM880.EmissionFilterSR" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="12/15/2020" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.108" SerialNumber="22-03_146388_0233">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>8</MaxPosition>
+     <ChangerElements>
+      <SpectralInfluencer Name="Plate" Id="" UniqueName="Beamsplitter.Plate" Model="" IsMounted="true" Position="1" Type="SpectralInfluencer">
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 420-480 + BP 495-550" Id="" UniqueName="AiryscanEmissionFilter.2372-550" Model="" IsMounted="true" Position="2" Type="SpectralInfluencer">
+       <OrderNumber>2372-550</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>420</Low>
+         <High>480</High>
+         <Efficiency>0.99</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>495</Low>
+         <High>550</High>
+         <Efficiency>0.99</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 420-480 + BP 570-630" Id="" UniqueName="AiryscanEmissionFilter.2284-690" Model="" IsMounted="true" Position="3" Type="SpectralInfluencer">
+       <OrderNumber>2284-690</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>422</Low>
+         <High>477</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>627</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 420-500 + LP 605" Id="" UniqueName="AiryscanEmissionFilter.2284-693" Model="" IsMounted="true" Position="4" Type="SpectralInfluencer">
+       <OrderNumber>2284-693</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>422</Low>
+         <High>497</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>607</Low>
+         <High>750</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 465-505 + BP 525-585" Id="" UniqueName="AiryscanEmissionFilter.2287-628" Model="" IsMounted="true" Position="5" Type="SpectralInfluencer">
+       <OrderNumber>2287-628</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>467</Low>
+         <High>499</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>530</Low>
+         <High>582</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 495-550 + BP 570-630" Id="" UniqueName="AiryscanEmissionFilter.2284-691" Model="" IsMounted="true" Position="6" Type="SpectralInfluencer">
+       <OrderNumber>2284-691</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>549</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>627</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 495-555 + LP 660" Id="" UniqueName="AiryscanEmissionFilter.2284-692" Model="" IsMounted="true" Position="7" Type="SpectralInfluencer">
+       <OrderNumber>2284-692</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>499</Low>
+         <High>557</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>659</Low>
+         <High>750</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="BP 570-620 + LP 660" Id="" UniqueName="AiryscanEmissionFilter.2183-198" Model="" IsMounted="true" Position="8" Type="SpectralInfluencer">
+       <OrderNumber>2183-198</OrderNumber>
+       <Features>Em</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas/>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>573</Low>
+         <High>620</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+        <WavelengthArea>
+         <Low>655</Low>
+         <High>750</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLaserModuleLKM980" Name="LaserModuleLKM980" UniqueName="LaserModuleLKM980" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="04/09/2021" FirmwareName="LKM980_App" FirmwareVersion="02.012" SerialNumber="000000-2258-797/V02"/>
+    <Device Id="CalibrationComponent_MTBLaserModuleLKM980" Name="CalibrationComponent_MTBLaserModuleLKM980" UniqueName="CalibrationComponent_MTBLaserModuleLKM980" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" NumberOfTasks="2">
+     <TaskProperty>
+      <Task>0</Task>
+     </TaskProperty>
+     <TaskProperty>
+      <Task>1</Task>
+     </TaskProperty>
+    </Device>
+    <Device Id="MTBLKM980Laser405" Name="Laser 405nm" UniqueName="Laserrack980.Laser405" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" HasOnOff="true" IsTunable="false" Wavelengths="405" Power="15" ShutterId="">
+     <Beam BeamId="MTBLKM980LaserBeam405"/>
+    </Device>
+    <Device Id="MTBLKM980Laser639" Name="Laser 639nm" UniqueName="Laserrack980.Laser639" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" HasOnOff="true" IsTunable="false" Wavelengths="639" Power="10" ShutterId="">
+     <Beam BeamId="MTBLKM980LaserBeam639"/>
+    </Device>
+    <Device Id="MTBLKM980LaserLine405" Name="Laserrack Laserline 405" UniqueName="Laserrack980.LaserLine405" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" LaserId="MTBLKM980Laser405" BeamId="MTBLKM980LaserBeam405" Wavelength="405" ExactWavelength="405.91000366210938" IsTunable="false" MaxPowerMilliWatts="15" MinWavelength="0" MaxWavelength="0" Stokes0="1" Stokes1="1" Stokes2="0" Stokes3="0" CalibrationWavelength="0">
+     <MinPosition>0.19994988499141231</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.062714582429996085</MaxDeviation>
+     <TypicalDeviation>0.062714582429996085</TypicalDeviation>
+     <StepWidth>0.12542916485999217</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|dB|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.19994988499141231</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="dB">
+       <Minimum>-26.990788413309566</Minimum>
+       <Maximum>0</Maximum>
+      </Range>
+     </PositionRanges>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>Halogen</LampType>
+     <AppConfigData>
+      <LaserLineConfiguration>
+       <CalibrationType>FirmwareCalibration</CalibrationType>
+       <CalibrationNeedsFiberReconnect>False</CalibrationNeedsFiberReconnect>
+      </LaserLineConfiguration>
+     </AppConfigData>
+    </Device>
+    <Device Id="MTBLKM980LaserLine639" Name="Laserrack Laserline 639" UniqueName="Laserrack980.LaserLine639" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" LaserId="MTBLKM980Laser639" BeamId="MTBLKM980LaserBeam639" Wavelength="639" ExactWavelength="638.5" IsTunable="false" MaxPowerMilliWatts="10" MinWavelength="0" MaxWavelength="0" Stokes0="1" Stokes1="1" Stokes2="0" Stokes3="0" CalibrationWavelength="0">
+     <MinPosition>0.00100018402978879</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.062714582429996085</MaxDeviation>
+     <TypicalDeviation>0.062714582429996085</TypicalDeviation>
+     <StepWidth>0.12542916485999217</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|dB|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.00100018402978879</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="dB">
+       <Minimum>-49.99920084231438</Minimum>
+       <Maximum>0</Maximum>
+      </Range>
+     </PositionRanges>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>Halogen</LampType>
+     <AppConfigData>
+      <LaserLineConfiguration>
+       <CalibrationType>FirmwareCalibration</CalibrationType>
+       <CalibrationNeedsFiberReconnect>True</CalibrationNeedsFiberReconnect>
+      </LaserLineConfiguration>
+     </AppConfigData>
+    </Device>
+    <Device Id="MTBLKM980Laser488" Name="Laser 488nm" UniqueName="Laserrack980.Laser488" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" HasOnOff="true" IsTunable="false" Wavelengths="488" Power="13" ShutterId="">
+     <Beam BeamId="MTBLKM980LaserBeam488"/>
+    </Device>
+    <Device Id="MTBLKM980Laser561" Name="Laser 561nm" UniqueName="Laserrack980.Laser561" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" HasOnOff="true" IsTunable="false" Wavelengths="561" Power="13" ShutterId="">
+     <Beam BeamId="MTBLKM980LaserBeam561"/>
+    </Device>
+    <Device Id="MTBLKM980LaserLine488" Name="Laserrack Laserline 488" UniqueName="Laserrack980.LaserLine488" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" LaserId="MTBLKM980Laser488" BeamId="MTBLKM980LaserBeam488" Wavelength="488" ExactWavelength="488.1300048828125" IsTunable="false" MaxPowerMilliWatts="13" MinWavelength="0" MaxWavelength="0" Stokes0="1" Stokes1="1" Stokes2="0" Stokes3="0" CalibrationWavelength="0">
+     <MinPosition>0.00100018402978879</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.062714582429996085</MaxDeviation>
+     <TypicalDeviation>0.062714582429996085</TypicalDeviation>
+     <StepWidth>0.12542916485999217</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|dB|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.00100018402978879</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="dB">
+       <Minimum>-49.99920084231438</Minimum>
+       <Maximum>0</Maximum>
+      </Range>
+     </PositionRanges>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>Halogen</LampType>
+     <AppConfigData>
+      <LaserLineConfiguration>
+       <CalibrationType>FirmwareCalibration</CalibrationType>
+       <CalibrationNeedsFiberReconnect>True</CalibrationNeedsFiberReconnect>
+      </LaserLineConfiguration>
+     </AppConfigData>
+    </Device>
+    <Device Id="MTBLKM980LaserLine561" Name="Laserrack Laserline 561" UniqueName="Laserrack980.LaserLine561" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="false" FirmwareDate="05/28/2019" FirmwareName="LasosMcfDemo_STM_F103APP" FirmwareVersion="01.032" SerialNumber="" LaserId="MTBLKM980Laser561" BeamId="MTBLKM980LaserBeam561" Wavelength="561" ExactWavelength="561.3499755859375" IsTunable="false" MaxPowerMilliWatts="13" MinWavelength="0" MaxWavelength="0" Stokes0="1" Stokes1="1" Stokes2="0" Stokes3="0" CalibrationWavelength="0">
+     <MinPosition>0.00100018402978879</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.062714582429996085</MaxDeviation>
+     <TypicalDeviation>0.062714582429996085</TypicalDeviation>
+     <StepWidth>0.12542916485999217</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|dB|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0.00100018402978879</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="dB">
+       <Minimum>-49.99920084231438</Minimum>
+       <Maximum>0</Maximum>
+      </Range>
+     </PositionRanges>
+     <Has3200K>false</Has3200K>
+     <HasOnOff>false</HasOnOff>
+     <LampType>Halogen</LampType>
+     <AppConfigData>
+      <LaserLineConfiguration>
+       <CalibrationType>FirmwareCalibration</CalibrationType>
+       <CalibrationNeedsFiberReconnect>True</CalibrationNeedsFiberReconnect>
+      </LaserLineConfiguration>
+     </AppConfigData>
+    </Device>
+    <Device Id="MTBLSM880LaserSafetyManager" Name="Laser Safety Manager" UniqueName="MTBLSM880LaserSafetyManager" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="">
+     <Mode Name="Custom"/>
+     <Mode Name="LSM">
+      <ParameterCollection Id="MTBSideportChanger">
+       <Position IsActivated="true">2</Position>
+      </ParameterCollection>
+      <ParameterCollection Id="MTBReflectorChanger">
+       <Position IsActivated="true">6</Position>
+      </ParameterCollection>
+     </Mode>
+    </Device>
+    <Device Id="" Name="" UniqueName="" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="MTBRTHardwareAdmin" Name="HardwareAdministrator" UniqueName="MTBRTHardwareAdmin" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" Dacs="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&#13;&#10;&lt;ArrayOfRtDacConfiguration xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;84&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;0&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1101&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;84&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.180392156862745&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;85&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;1&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1102&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;85&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.513725490196078&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;86&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;2&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1103&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;86&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.274509803921569&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;87&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;3&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1104&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;87&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.0901960784313725&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;88&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;4&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1105&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;88&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.564705882352941&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;89&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;5&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1106&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;89&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;90&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;6&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1107&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;90&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.168627450980392&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;91&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;7&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1108&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;91&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.498039215686275&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;92&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;8&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1109&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;92&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.27843137254902&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;93&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;9&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1110&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;93&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.0823529411764706&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;94&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;10&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1111&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;94&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.6&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;95&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;11&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC1112&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;95&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;77&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;12&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RtScannerDACX&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;77&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;-1&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;78&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;13&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RtScannerDACY&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;78&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;-1&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;783&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;14&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_HV_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;783&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;784&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;15&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_HV_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;784&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;785&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;16&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_HV_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;785&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;786&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;17&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_HV_FLIM&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;786&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;794&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;18&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;794&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;795&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;19&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;795&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;797&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;20&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_FLIM&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;797&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;798&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;21&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;798&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015626&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;799&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;22&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;799&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015626&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;801&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;23&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_FLIM&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;801&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;827&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;24&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OvldHV_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;827&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;828&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;25&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OvldHV_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;828&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;829&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;26&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OvldHV_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;829&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;832&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;27&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;832&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;833&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;28&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;833&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;834&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;29&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;834&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;835&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;30&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03204&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;835&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;836&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;31&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03205&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;836&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;837&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;32&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03206&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;837&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;838&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;33&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03207&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;838&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;839&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;34&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03208&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;839&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;840&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;35&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03209&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;840&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;841&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;36&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03210&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;841&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;842&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;37&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03211&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;842&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;843&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;38&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03212&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;843&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;844&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;39&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03213&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;844&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;845&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;40&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03214&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;845&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;846&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;41&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03215&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;846&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;847&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;42&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03216&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;847&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;848&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;43&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03217&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;848&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;849&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;44&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03218&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;849&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;850&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;45&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03219&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;850&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;851&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;46&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03220&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;851&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;852&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;47&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03221&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;852&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;853&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;48&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03222&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;853&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;854&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;49&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03223&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;854&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;855&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;50&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03224&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;855&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;856&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;51&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03225&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;856&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;857&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;52&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03226&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;857&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;858&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;53&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03227&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;858&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;859&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;54&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03228&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;859&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;860&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;55&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03229&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;860&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;861&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;56&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03230&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;861&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;862&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;57&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03231&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;862&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;863&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;58&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_OFFS_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;863&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;864&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;59&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;864&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;865&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;60&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;865&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;866&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;61&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;866&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;867&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;62&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03204&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;867&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;868&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;63&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03205&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;868&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;869&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;64&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03206&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;869&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;870&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;65&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03207&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;870&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;871&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;66&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03208&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;871&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;872&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;67&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03209&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;872&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;873&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;68&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03210&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;873&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;874&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;69&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03211&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;874&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;875&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;70&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03212&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;875&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;876&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;71&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03213&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;876&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;877&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;72&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03214&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;877&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;878&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;73&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03215&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;878&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;879&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;74&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03216&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;879&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;880&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;75&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03217&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;880&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;881&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;76&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03218&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;881&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;882&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;77&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03219&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;882&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;883&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;78&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03220&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;883&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;884&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;79&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03221&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;884&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;885&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;80&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03222&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;885&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;886&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;81&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03223&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;886&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;887&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;82&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03224&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;887&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;888&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;83&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03225&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;888&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;889&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;84&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03226&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;889&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;890&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;85&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03227&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;890&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;891&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;86&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03228&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;891&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;892&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;87&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03229&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;892&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;893&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;88&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03230&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;893&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;894&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;89&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03231&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;894&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;895&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;90&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DAC_GAIN_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;895&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;1009&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;91&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;DummyDac_FLIM&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;1009&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;783&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;92&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaHVDac&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;783&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;818&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;93&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaShOvldAdc&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;818&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.0008545&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;8&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;819&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;94&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOvldAdc&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;819&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.9375&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;827&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;95&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaHVOvldDac&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;827&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;12&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;832&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;96&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset01&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;832&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;833&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;97&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset02&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;833&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;834&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;98&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset03&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;834&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;835&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;99&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset04&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;835&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;836&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;100&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset05&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;836&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;837&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;101&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset06&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;837&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;838&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;102&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset07&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;838&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;839&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;103&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset08&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;839&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;840&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;104&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset09&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;840&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;841&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;105&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset10&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;841&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;842&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;106&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset11&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;842&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;843&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;107&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset12&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;843&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;844&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;108&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset13&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;844&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;845&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;109&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset14&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;845&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;846&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;110&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset15&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;846&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;847&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;111&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset16&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;847&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;848&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;112&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset17&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;848&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;849&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;113&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset18&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;849&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;850&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;114&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset19&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;850&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;851&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;115&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset20&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;851&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;852&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;116&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset21&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;852&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;853&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;117&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset22&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;853&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;854&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;118&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset23&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;854&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;855&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;119&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset24&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;855&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;856&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;120&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset25&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;856&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;857&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;121&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset26&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;857&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;858&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;122&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset27&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;858&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;859&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;123&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset28&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;859&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;860&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;124&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset29&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;860&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;861&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;125&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset30&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;861&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;862&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;126&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset31&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;862&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;863&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;127&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaOffset32&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;863&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;864&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;128&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain01&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;864&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;865&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;129&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain02&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;865&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;866&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;130&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain03&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;866&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;867&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;131&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain04&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;867&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;868&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;132&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain05&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;868&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;869&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;133&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain06&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;869&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;870&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;134&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain07&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;870&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;871&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;135&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain08&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;871&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;872&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;136&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain09&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;872&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;873&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;137&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain10&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;873&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;874&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;138&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain11&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;874&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;875&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;139&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain12&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;875&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;876&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;140&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain13&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;876&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;877&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;141&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain14&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;877&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;878&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;142&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain15&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;878&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;879&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;143&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain16&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;879&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;880&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;144&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain17&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;880&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;881&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;145&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain18&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;881&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;882&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;146&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain19&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;882&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;883&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;147&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain20&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;883&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;884&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;148&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain21&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;884&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;885&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;149&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain22&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;885&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;886&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;150&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain23&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;886&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;887&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;151&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain24&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;887&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;888&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;152&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain25&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;888&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;889&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;153&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain26&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;889&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;890&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;154&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain27&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;890&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;891&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;155&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain28&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;891&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;892&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;156&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain29&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;892&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;893&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;157&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain30&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;893&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;894&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;158&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain31&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;894&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;895&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;159&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGain32&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;895&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0.015625&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;379&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;160&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;AomIfAnalogControlDac&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;379&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;-1&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;14&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;365&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;161&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;AomIfDigitalControlDac&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;365&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;-1&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;true&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;299&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;162&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch1&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;299&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;300&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;163&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch2&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;300&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;301&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;164&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch3&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;301&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;302&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;165&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch4&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;302&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;303&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;166&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch5&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;303&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;304&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;167&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch6&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;304&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;310&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;168&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch9&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;310&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;  &lt;RtDacConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;311&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;169&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DAC_Ch10&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;311&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;MaximumValue&gt;1&lt;/MaximumValue&gt;&#13;&#10;    &lt;MinimumValue&gt;0&lt;/MinimumValue&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;0&lt;/PostInitValue&gt;&#13;&#10;    &lt;Resolution&gt;16&lt;/Resolution&gt;&#13;&#10;  &lt;/RtDacConfiguration&gt;&#13;&#10;&lt;/ArrayOfRtDacConfiguration&gt;" Adcs="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&#13;&#10;&lt;ArrayOfRtAdcConfiguration xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; /&gt;" IoPorts="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&#13;&#10;&lt;ArrayOfRtIoPortConfiguration xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;0&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;UserPortLow&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;519&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;1&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;UserPortIn&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;771&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_In&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;80&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;2&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;REG1101&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;80&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;81&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;3&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;REG1102&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;81&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;64&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;4&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG1101&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;64&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;66&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;5&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG1103&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;66&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;68&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;6&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG1105&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;68&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;65&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;7&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG1102&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;65&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;67&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;8&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG1104&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;67&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;79&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;9&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;REG1106&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;79&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;10&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_Ctrl_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;11&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_Mask_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;771&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;779&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;12&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_Sample_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;779&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;780&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;13&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_GM_03204_Ch32&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;780&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;780&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;14&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_GM_03204_Ch34&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;780&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;787&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;15&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCOvldLvl_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;787&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;788&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;16&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCThOvld_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;788&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;789&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;17&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCOvldLvl_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;789&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;790&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;18&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCThOvld_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;790&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;792&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;19&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;StatusHV&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;792&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;793&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;20&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_ADCPwrUp_03205&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;793&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;810&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;21&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_PCDecr_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;810&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;811&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;22&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_PCThOvld_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;811&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;812&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;23&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_HavDecr_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;812&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;813&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;24&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_HavThOvld_03234&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;813&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;818&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;25&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCOvldLvl_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;818&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;819&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;26&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_ADCThOvld_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;819&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;822&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;27&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_PCDecr_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;822&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;823&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;28&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_PCThOvld_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;823&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;824&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;29&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_HavDecr_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;824&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;825&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;30&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_HavThOvld_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;825&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;826&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;31&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_HavDecr_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;826&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;831&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;32&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;RDAC_HavThOvld_03233&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;831&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;896&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;33&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;896&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;897&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;34&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;897&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;898&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;35&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;898&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;899&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;36&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03204&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;899&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;900&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;37&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03205&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;900&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;901&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;38&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03206&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;901&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;902&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;39&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03207&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;902&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;903&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;40&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03208&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;903&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;904&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;41&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03209&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;904&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;905&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;42&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03210&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;905&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;906&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;43&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03211&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;906&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;907&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;44&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03212&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;907&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;908&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;45&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03213&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;908&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;909&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;46&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03214&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;909&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;910&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;47&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03215&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;910&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;911&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;48&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03216&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;911&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;912&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;49&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03217&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;912&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;913&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;50&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03218&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;913&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;914&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;51&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03219&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;914&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;915&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;52&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03220&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;915&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;916&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;53&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03221&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;916&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;917&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;54&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03222&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;917&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;918&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;55&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03223&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;918&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;919&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;56&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03224&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;919&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;920&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;57&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03225&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;920&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;921&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;58&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03226&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;921&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;922&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;59&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03227&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;922&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;923&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;60&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03228&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;923&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;924&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;61&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03229&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;924&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;925&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;62&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03230&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;925&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;926&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;63&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03231&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;926&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;927&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;64&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_03232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;927&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;65&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaControlMain&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;66&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaMaskStatus&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;771&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;779&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;67&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaSample&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;779&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;68&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaGrabChannels&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;792&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;69&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaStatusHV&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;792&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_In&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;793&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;70&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaAdcPowerUp&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;793&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;816&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;71&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableMetaChannelsA&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;816&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;817&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;72&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableMetaChannelsB&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;817&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;824&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;73&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaHavDec&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;824&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;825&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;74&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaHavOvld&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;825&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;944&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;75&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaXAddr&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;944&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;945&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;76&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaXData&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;945&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;896&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;77&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13201&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;896&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;897&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;78&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13202&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;897&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;898&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;79&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13203&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;898&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;899&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;80&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13204&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;899&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;900&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;81&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13205&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;900&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;901&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;82&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13206&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;901&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;902&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;83&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13207&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;902&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;903&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;84&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13208&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;903&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;904&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;85&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13209&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;904&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;905&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;86&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13210&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;905&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;906&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;87&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13211&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;906&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;907&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;88&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13212&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;907&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;908&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;89&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13213&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;908&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;909&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;90&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13214&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;909&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;910&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;91&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13215&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;910&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;911&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;92&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13216&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;911&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;912&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;93&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13217&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;912&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;913&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;94&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13218&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;913&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;914&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;95&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13219&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;914&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;915&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;96&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13220&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;915&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;916&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;97&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13221&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;916&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;917&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;98&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13222&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;917&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;918&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;99&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13223&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;918&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;919&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;100&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13224&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;919&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;920&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;101&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13225&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;920&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;921&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;102&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13226&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;921&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;922&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;103&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13227&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;922&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;923&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;104&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13228&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;923&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;924&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;105&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13229&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;924&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;925&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;106&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13230&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;925&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;926&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;107&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13231&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;926&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;927&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;108&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;iREG_BIN_13232&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;927&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;289&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;109&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_iREG_Ctrl&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;289&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;291&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;110&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_iREG_Mask&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;291&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;111&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_LaserCtrl&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;112&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Blanking&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;309&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;113&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_DirectMod_Select&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;309&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;314&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;114&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_SubChannelSel_In&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;314&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;  &lt;RtIoPortConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;315&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;115&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_SubChannelSel_Out&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;315&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;IoMode&gt;eRtIOPortMode_Out&lt;/IoMode&gt;&#13;&#10;  &lt;/RtIoPortConfiguration&gt;&#13;&#10;&lt;/ArrayOfRtIoPortConfiguration&gt;" Switches="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&#13;&#10;&lt;ArrayOfRtSwitchConfiguration xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;79&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;0&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableAmplifierScannerX&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;79&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;79&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;1&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableAmplifierScannerY&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;79&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;3&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;79&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;2&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableScannerX&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;79&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;2&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;67&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;3&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableScannerXRead&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;67&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;9&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;79&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;4&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableScannerY&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;79&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;5&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;67&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;5&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;EnableScannerYRead&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;67&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;10&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;65&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;6&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;ReadScannerStatus&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;65&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;11&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;7&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LSM_HS_HAVReset&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;7&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;8&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LSM_HS_HVRelais&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;10&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;false&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;9&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LSM_HS_Enable_Ch33&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;10&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LSM_HS_Enable_Ch34&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;1&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;11&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;FLIM_Enable_Ch36&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;3&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;12&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LSM_HS_Enable_Meta&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;13&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaResetHvOverload&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;7&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;14&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaHvRelais&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;10&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;false&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;769&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;15&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCrosstalk&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;769&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;11&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;16&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh01&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;17&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh02&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;18&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh03&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;19&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh04&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;20&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh05&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;21&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh06&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;22&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh07&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;23&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh08&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;24&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh09&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;25&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh10&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;26&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh11&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;27&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh12&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;28&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh13&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;29&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh14&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;30&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh15&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;31&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh16&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;32&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh17&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;33&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh18&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;34&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh19&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;35&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh20&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;36&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh21&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;37&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh22&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;38&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh23&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;39&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh24&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;40&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh25&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;41&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh26&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;42&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh27&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;43&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh28&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;44&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh29&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;45&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh30&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;46&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh31&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;791&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;47&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;MetaEnableCh32&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;791&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;8&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;371&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;48&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;AomIfEnableSwitch&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;371&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;12&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;49&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch445&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;50&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch488&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;1&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;51&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch514&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;2&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;52&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch561&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;3&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;53&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch594&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;4&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;54&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Switch639&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;5&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;55&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch1Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;56&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch2Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;1&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;57&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch3Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;2&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;58&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch4Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;3&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;59&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch5Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;4&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;307&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;60&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch6Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;307&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;5&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;61&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch9Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;6&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;  &lt;RtSwitchConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;312&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;62&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;LKM980_Ch10Blank&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;312&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;7&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;PostInit&gt;false&lt;/PostInit&gt;&#13;&#10;    &lt;PostInitValue&gt;false&lt;/PostInitValue&gt;&#13;&#10;  &lt;/RtSwitchConfiguration&gt;&#13;&#10;&lt;/ArrayOfRtSwitchConfiguration&gt;" Trigger="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&#13;&#10;&lt;ArrayOfRtTriggerConfiguration xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;0&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_00&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;0&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Out 1&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;true&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;1&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_01&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;1&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Out 2&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;true&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;2&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_02&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;2&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Out 3&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;true&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;3&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_03&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;3&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Out 4&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;true&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;4&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_04&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;4&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Stack&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;-16&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;true&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;5&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_05&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;5&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Grabbing&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;-1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;true&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;6&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_08&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;6&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Frame&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;-16&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;true&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;519&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;7&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;Trigger_09&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;7&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger Line&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;-16&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;false&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;true&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;8&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;TriggerIn_00&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;8&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;false&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger In 1&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;true&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;9&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;TriggerIn_01&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;9&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger In 2&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;true&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;10&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;TriggerIn_02&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;10&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger In 3&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;true&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;  &lt;RtTriggerConfiguration&gt;&#13;&#10;    &lt;BaseConfiguration&gt;&#13;&#10;      &lt;Address&gt;771&lt;/Address&gt;&#13;&#10;      &lt;Index&gt;11&lt;/Index&gt;&#13;&#10;      &lt;InterfaceBoard&gt;0&lt;/InterfaceBoard&gt;&#13;&#10;      &lt;Name&gt;TriggerIn_03&lt;/Name&gt;&#13;&#10;      &lt;RealtimeIndex&gt;11&lt;/RealtimeIndex&gt;&#13;&#10;      &lt;Bit&gt;0&lt;/Bit&gt;&#13;&#10;    &lt;/BaseConfiguration&gt;&#13;&#10;    &lt;Polarity&gt;true&lt;/Polarity&gt;&#13;&#10;    &lt;IsUsableByRealtimeSystem&gt;true&lt;/IsUsableByRealtimeSystem&gt;&#13;&#10;    &lt;UiName&gt;Trigger In 4&lt;/UiName&gt;&#13;&#10;    &lt;FirstPixelOfTrigger&gt;0&lt;/FirstPixelOfTrigger&gt;&#13;&#10;    &lt;PulseLengthInPixelOfRtTrigger&gt;1&lt;/PulseLengthInPixelOfRtTrigger&gt;&#13;&#10;    &lt;IsPulseLengthInPixel&gt;true&lt;/IsPulseLengthInPixel&gt;&#13;&#10;    &lt;SupportsInput&gt;true&lt;/SupportsInput&gt;&#13;&#10;    &lt;SupportsOutput&gt;false&lt;/SupportsOutput&gt;&#13;&#10;    &lt;IsLineSync&gt;false&lt;/IsLineSync&gt;&#13;&#10;    &lt;IsFrameSync&gt;false&lt;/IsFrameSync&gt;&#13;&#10;    &lt;IsVolumeSync&gt;false&lt;/IsVolumeSync&gt;&#13;&#10;    &lt;IsGrabbingSync&gt;false&lt;/IsGrabbingSync&gt;&#13;&#10;  &lt;/RtTriggerConfiguration&gt;&#13;&#10;&lt;/ArrayOfRtTriggerConfiguration&gt;"/>
+    <Device Id="RealtimeSystem" Name="Realtimesystem" UniqueName="Realtimesystem" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" BaseClock="250000000" RtInterfaceType="MicoIfHS"/>
+    <Device Id="MTBLSMImagingDevice" Name="LSM 980" UniqueName="LSM880.ImagingDevice" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" MaximumScannerDistance="0.017741974428596326" Zoom1ScannerDistance="0.0084853" MinimumZoom="0.6" MaximumZoom="40" MinimumZoomForFullRotation="1" SystemSerialNumber="2842001059" IsSimulated="false"/>
+    <Device Id="MTBLSM880BeamshiftCompensatorVis" Name="BeamshiftCompensator" UniqueName="MTBLSM880BeamshiftCompensatorVis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" XAxisId="MTBLSM880BeamshiftCompensatorVisXAxis" YAxisId="MTBLSM880BeamshiftCompensatorVisYAxis"/>
+    <Device Id="MTBLSM880BeamshiftCompensatorInvis" Name="BeamshiftCompensator" UniqueName="MTBLSM880BeamshiftCompensatorInvis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber="" XAxisId="MTBLSM880BeamshiftCompensatorInvisXAxis" YAxisId="MTBLSM880BeamshiftCompensatorInvisYAxis"/>
+    <Device Id="MTBLSM880PinLong" Name="SpectralGroup Pins long" UniqueName="LSM880.SpectralGroup.Pins.Long" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  577  /V4">
+     <MinPosition>397.512</MinPosition>
+     <MaxPosition>757.271</MaxPosition>
+     <MaxDeviation>0.11450381679389313</MaxDeviation>
+     <TypicalDeviation>0.11450381679389313</TypicalDeviation>
+     <StepWidth>0.22900763358778625</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>397.512</Minimum>
+       <Maximum>757.271</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1572</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880PinShort" Name="SpectralGroup Pins short" UniqueName="LSM880.SpectralGroup.Pins.Short" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  577  /V4">
+     <MinPosition>372.729</MinPosition>
+     <MaxPosition>732.488</MaxPosition>
+     <MaxDeviation>0.11415525114155251</MaxDeviation>
+     <TypicalDeviation>0.11415525114155251</TypicalDeviation>
+     <StepWidth>0.228310502283105</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>372.729</Minimum>
+       <Maximum>732.488</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1572</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880SpectralGroup" Name="SpectralGroup" UniqueName="MTBLSM880SpectralGroup" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  577  /V4" NumberOfLaserBlockers="2">
+     <Bands>
+      <Band DetectorId="MTBLSM880DetectorLong" MinLeft="384.02061780584091" MaxLeft="757.97205091502565" MinRight="390.61694597650262" MaxRight="757.97205091502565"/>
+      <Band DetectorId="MTBLSM880DetectorMeta" MinLeft="380.4429223744292" MaxLeft="735.97205091502565" MinRight="380.4429223744292" MaxRight="757.97205091502565"/>
+      <Band DetectorId="MTBLSM880DetectorShort" MinLeft="380.4429223744292" MaxLeft="735.97205091502565" MinRight="380.4429223744292" MaxRight="735.97205091502565"/>
+     </Bands>
+     <SlitWidth>3</SlitWidth>
+     <SlitWidth>5</SlitWidth>
+     <SlitWidth>10</SlitWidth>
+    </Device>
+    <Device Id="MTBLSM880ApertureLong" Name="SpectralGroup Apertures long" UniqueName="LSM880.SpectralGroup.Apertures.Long" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  628  /V4">
+     <MinPosition>381.02799999999996</MinPosition>
+     <MaxPosition>762.771</MaxPosition>
+     <MaxDeviation>0.11443683037837708</MaxDeviation>
+     <TypicalDeviation>0.11443683037837708</TypicalDeviation>
+     <StepWidth>0.22887366075675417</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>381.02799999999996</Minimum>
+       <Maximum>762.771</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1668</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880ApertureShort" Name="SpectralGroup Apertures short" UniqueName="LSM880.SpectralGroup.Apertures.Short" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  628  /V4">
+     <MinPosition>367.229</MinPosition>
+     <MaxPosition>748.972</MaxPosition>
+     <MaxDeviation>0.1151378216823794</MaxDeviation>
+     <TypicalDeviation>0.1151378216823794</TypicalDeviation>
+     <StepWidth>0.23027564336475881</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>367.229</Minimum>
+       <Maximum>748.972</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1668</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880PrismLong" Name="SpectralGroup Prisms long" UniqueName="LSM880.SpectralGroup.Prisms.Long" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  617  /V4">
+     <MinPosition>374.805</MinPosition>
+     <MaxPosition>758.151</MaxPosition>
+     <MaxDeviation>0.11443683037837708</MaxDeviation>
+     <TypicalDeviation>0.11443683037837708</TypicalDeviation>
+     <StepWidth>0.22887366075675417</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>374.805</Minimum>
+       <Maximum>758.151</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1675</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880PrismShort" Name="SpectralGroup Prisms short" UniqueName="LSM880.SpectralGroup.Prisms.Short" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  617  /V4">
+     <MinPosition>360.849</MinPosition>
+     <MaxPosition>744.19499999999994</MaxPosition>
+     <MaxDeviation>0.11443683037837711</MaxDeviation>
+     <TypicalDeviation>0.11443683037837711</TypicalDeviation>
+     <StepWidth>0.22887366075675422</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>360.849</Minimum>
+       <Maximum>744.19499999999994</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>1675</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880WedgeLong" Name="SpectralGroup Wedges long" UniqueName="LSM880.SpectralGroup.Wedges.Long" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  571  /V4">
+     <MinPosition>-213.04000000000002</MinPosition>
+     <MaxPosition>11.903</MaxPosition>
+     <MaxDeviation>0.047858050642007481</MaxDeviation>
+     <TypicalDeviation>0.047858050642007481</TypicalDeviation>
+     <StepWidth>0.095716101284014962</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>-213.04000000000002</Minimum>
+       <Maximum>11.903</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>2320</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880WedgeShort" Name="SpectralGroup Wedges short" UniqueName="LSM880.SpectralGroup.Wedges.Short" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="144367  571  /V4">
+     <MinPosition>-11.903</MinPosition>
+     <MaxPosition>213.04000000000002</MaxPosition>
+     <MaxDeviation>0.048103005475747765</MaxDeviation>
+     <TypicalDeviation>0.048103005475747765</TypicalDeviation>
+     <StepWidth>0.09620601095149553</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>-11.903</Minimum>
+       <Maximum>213.04000000000002</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>2320</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880Grating" Name="SpectralGroup Grating Servo" UniqueName="LSM880.SpectralGroup.Grating" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="145990  57  /V5" CalibratedNeutralWavelength="551.84118928717317">
+     <MinPosition>469.15200000000004</MinPosition>
+     <MaxPosition>635.2768</MaxPosition>
+     <MaxDeviation>0.16150000000000006</MaxDeviation>
+     <TypicalDeviation>0.16150000000000006</TypicalDeviation>
+     <StepWidth>0.32300000000000012</StepWidth>
+     <PositionUnit>nm</PositionUnit>
+     <SupportedUnits>%|nm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="nm">
+       <Minimum>469.15200000000004</Minimum>
+       <Maximum>635.2768</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>515</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880BeamShaperWheelInvis" Name="BeamShaper Invis" UniqueName="LSM880.BeamShaperChangerInvis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/28/2019" FirmwareName="MotorControl" FirmwareVersion="01.025" SerialNumber="21-12_145917_0025">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>20</MaxPosition>
+     <ChangerElements>
+      <BeamshapeCircle Name="Circle_6500" Id="" UniqueName="Beamshape.Circle1" Model="" IsMounted="true" Position="1" Type="BeamShapeCircle" Diameter="6500"/>
+      <BeamshapeRectangle Name="Slit_950" Id="" UniqueName="Beamshape.Rectangle5" Model="" IsMounted="true" Position="2" Type="BeamShapeRectangle" Width="6500" Height="950"/>
+      <BeamshapeRectangle Name="Slit_1180" Id="" UniqueName="Beamshape.Rectangle6" Model="" IsMounted="true" Position="3" Type="BeamShapeRectangle" Width="6500" Height="1180"/>
+      <BeamshapeRectangle Name="Slit_1460" Id="" UniqueName="Beamshape.Rectangle7" Model="" IsMounted="true" Position="4" Type="BeamShapeRectangle" Width="6500" Height="1460"/>
+      <BeamshapeRectangle Name="Slit_1820" Id="" UniqueName="Beamshape.Rectangle8" Model="" IsMounted="true" Position="5" Type="BeamShapeRectangle" Width="6500" Height="1820"/>
+      <BeamshapeRectangle Name="Slit_2260" Id="" UniqueName="Beamshape.Rectangle9" Model="" IsMounted="true" Position="6" Type="BeamShapeRectangle" Width="6500" Height="2260"/>
+      <BeamshapeRectangle Name="Slit_2800" Id="" UniqueName="Beamshape.Rectangle10" Model="" IsMounted="true" Position="7" Type="BeamShapeRectangle" Width="6500" Height="2800"/>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="8" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="9" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="10" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="11" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="12" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="13" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="14" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="15" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <BeamshapeCross Name="Cross_6500x400" Id="" UniqueName="Beamshape.Cross1" Model="" IsMounted="true" Position="16" Type="BeamShapeCross" BarLength="6500" BarThickness="400"/>
+      <BeamshapeRectangle Name="Slit_400" Id="" UniqueName="Beamshape.Rectangle1" Model="" IsMounted="true" Position="17" Type="BeamShapeRectangle" Width="6500" Height="400"/>
+      <BeamshapeRectangle Name="Slit_500" Id="" UniqueName="Beamshape.Rectangle2" Model="" IsMounted="true" Position="18" Type="BeamShapeRectangle" Width="6500" Height="500"/>
+      <BeamshapeRectangle Name="Slit_620" Id="" UniqueName="Beamshape.Rectangle3" Model="" IsMounted="true" Position="19" Type="BeamShapeRectangle" Width="6500" Height="620"/>
+      <BeamshapeRectangle Name="Slit_770" Id="" UniqueName="Beamshape.Rectangle4" Model="" IsMounted="true" Position="20" Type="BeamShapeRectangle" Width="6500" Height="770"/>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880BeamShaperWheelVis" Name="BeamShaper Vis" UniqueName="LSM880.BeamShaperChangerVis" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="03/28/2019" FirmwareName="MotorControl" FirmwareVersion="01.025" SerialNumber="21-12_145917_0025">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>20</MaxPosition>
+     <ChangerElements>
+      <BeamshapeCircle Name="Circle_6500" Id="" UniqueName="Beamshape.Circle1" Model="" IsMounted="true" Position="1" Type="BeamShapeCircle" Diameter="6500"/>
+      <BeamshapeRectangle Name="Slit_950" Id="" UniqueName="Beamshape.Rectangle5" Model="" IsMounted="true" Position="2" Type="BeamShapeRectangle" Width="6500" Height="950"/>
+      <BeamshapeRectangle Name="Slit_1180" Id="" UniqueName="Beamshape.Rectangle6" Model="" IsMounted="true" Position="3" Type="BeamShapeRectangle" Width="6500" Height="1180"/>
+      <BeamshapeRectangle Name="Slit_1460" Id="" UniqueName="Beamshape.Rectangle7" Model="" IsMounted="true" Position="4" Type="BeamShapeRectangle" Width="6500" Height="1460"/>
+      <BeamshapeRectangle Name="Slit_1820" Id="" UniqueName="Beamshape.Rectangle8" Model="" IsMounted="true" Position="5" Type="BeamShapeRectangle" Width="6500" Height="1820"/>
+      <BeamshapeRectangle Name="Slit_2260" Id="" UniqueName="Beamshape.Rectangle9" Model="" IsMounted="true" Position="6" Type="BeamShapeRectangle" Width="6500" Height="2260"/>
+      <BeamshapeRectangle Name="Slit_2800" Id="" UniqueName="Beamshape.Rectangle10" Model="" IsMounted="true" Position="7" Type="BeamShapeRectangle" Width="6500" Height="2800"/>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="8" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="9" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="10" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="11" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="12" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="13" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="14" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <ChangerElement Name="BlackPlate" Id="" UniqueName="Beamshape.BlackPlate" Model="" IsMounted="true" Position="15" Type="SpectralInfluencer">
+       <Features>None</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </ChangerElement>
+      <BeamshapeCross Name="Cross_6500x400" Id="" UniqueName="Beamshape.Cross1" Model="" IsMounted="true" Position="16" Type="BeamShapeCross" BarLength="6500" BarThickness="400"/>
+      <BeamshapeRectangle Name="Slit_400" Id="" UniqueName="Beamshape.Rectangle1" Model="" IsMounted="true" Position="17" Type="BeamShapeRectangle" Width="6500" Height="400"/>
+      <BeamshapeRectangle Name="Slit_500" Id="" UniqueName="Beamshape.Rectangle2" Model="" IsMounted="true" Position="18" Type="BeamShapeRectangle" Width="6500" Height="500"/>
+      <BeamshapeRectangle Name="Slit_620" Id="" UniqueName="Beamshape.Rectangle3" Model="" IsMounted="true" Position="19" Type="BeamShapeRectangle" Width="6500" Height="620"/>
+      <BeamshapeRectangle Name="Slit_770" Id="" UniqueName="Beamshape.Rectangle4" Model="" IsMounted="true" Position="20" Type="BeamShapeRectangle" Width="6500" Height="770"/>
+     </ChangerElements>
+    </Device>
+    <Device Id="MTBLSM880DetectorMeta" Name="Spectral" UniqueName="MTBLSM880DetectorMeta" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="true" IsDetector="true" FirmwareDate="06/29/2017" FirmwareName="META-HS" FirmwareVersion="01.062" SerialNumber="22-02_146378_0035" MinDigGain="0.3" MaxDigGain="15" MinInputHVValue="500" MaxInputHVValue="1250" HasOffValue="true" HasDigitalAmplifier="true" OffValue="0" DetectionChannelCount="32" HasOverloadDetection="true" DigiGainFactorLambda="3" DigiGainFactorChannel="0.75" NumberInDetectorGroup="0" PipelineDelay="0" EnableHvSwitchId="LSM_HS_HVRelais" MaximumPhotonCountingFrequency="0" WavelengthLow="300" WavelengthHigh="720" SpectralBandwidth="8.8574357128267955">
+     <DetectorUsage>MultiChannel</DetectorUsage>
+     <DetectorTechnology>GaAsP</DetectorTechnology>
+     <DetectorFeatures>Binning, Integration</DetectorFeatures>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+     <SubDetectorFeatures/>
+    </Device>
+    <Device Id="MTBLSM880Sbs" Name="LSM880.SBS" UniqueName="LSM880.SBS" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="11/19/2009" FirmwareName="MC-1-2-SM" FirmwareVersion="01.038" SerialNumber="145946  99  /V5">
+     <MinPosition>1</MinPosition>
+     <MaxPosition>8</MaxPosition>
+     <ChangerElements>
+      <SpectralInfluencer Name="Mirror" Id="" UniqueName="SecondaryBeamsplitter.453001-4023-000" Model="" IsMounted="true" Position="1" Type="SpectralInfluencer">
+       <OrderNumber>453001-4023-000</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>1</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>200</Low>
+         <High>2000</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS SP 505" Id="" UniqueName="SecondaryBeamsplitter.2220-614" Model="" IsMounted="true" Position="2" Type="SpectralInfluencer">
+       <OrderNumber>2220-614</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>511</Low>
+         <High>750</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>350</Low>
+         <High>499</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS LP 525" Id="" UniqueName="SecondaryBeamsplitter.2415-594" Model="" IsMounted="true" Position="3" Type="SpectralInfluencer">
+       <OrderNumber>2415-594</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>517</High>
+         <Efficiency>0.01</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>517</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>527</Low>
+         <High>900</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS LP 640" Id="" UniqueName="SecondaryBeamsplitter.2415-595" Model="" IsMounted="true" Position="4" Type="SpectralInfluencer">
+       <OrderNumber>2415-595</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>640</High>
+         <Efficiency>0.01</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>640</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>643</Low>
+         <High>900</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS SP 550" Id="" UniqueName="SecondaryBeamsplitter.2301-266" Model="" IsMounted="true" Position="5" Type="SpectralInfluencer">
+       <OrderNumber>2301-266</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>560</Low>
+         <High>750</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>548</High>
+         <Efficiency>0.93</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS LP 740" Id="" UniqueName="SecondaryBeamsplitter.2415-596" Model="" IsMounted="true" Position="6" Type="SpectralInfluencer">
+       <OrderNumber>2415-596</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>728</High>
+         <Efficiency>0.01</Efficiency>
+        </WavelengthArea>
+       </BlockWavelengthAreas>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>736</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>743</Low>
+         <High>900</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS SP 615" Id="" UniqueName="SecondaryBeamsplitter.2035-352" Model="" IsMounted="true" Position="7" Type="SpectralInfluencer">
+       <OrderNumber>2035-352</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>622</Low>
+         <High>750</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>608</High>
+         <Efficiency>0.9</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+      <SpectralInfluencer Name="SBS Plate 10°" Id="" UniqueName="SecondaryBeamsplitter.2415-597" Model="" IsMounted="true" Position="8" Type="SpectralInfluencer">
+       <OrderNumber>2415-597</OrderNumber>
+       <Features>BS</Features>
+       <BlockWavelengthAreas/>
+       <ReflectionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0</Efficiency>
+        </WavelengthArea>
+       </ReflectionWavelengthAreas>
+       <TransmissionWavelengthAreas>
+        <WavelengthArea>
+         <Low>380</Low>
+         <High>900</High>
+         <Efficiency>0.98</Efficiency>
+        </WavelengthArea>
+       </TransmissionWavelengthAreas>
+      </SpectralInfluencer>
+     </ChangerElements>
+     <ReflectedSuccessorID>MTBLSM880InternalDetectors</ReflectedSuccessorID>
+     <TransmissionSuccessorID>MTBLSM880ExternalDetectors</TransmissionSuccessorID>
+    </Device>
+    <Device Id="MTBLSM880ZoomSRL2" Name="Zoom L2" UniqueName="LSM880.SR.DeviceZoomSRL2" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/25/2022" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.917" SerialNumber="22-04_147434_0053">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.0023256895669566025</MaxDeviation>
+     <TypicalDeviation>0.0023256895669566025</TypicalDeviation>
+     <StepWidth>0.0046513791339132049</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>20800</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880ZoomSRL4" Name="Zoom L4" UniqueName="LSM880.SR.DeviceZoomSRL4" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/25/2022" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.917" SerialNumber="22-04_147434_0053">
+     <MinPosition>0</MinPosition>
+     <MaxPosition>100</MaxPosition>
+     <MaxDeviation>0.0041670139178264856</MaxDeviation>
+     <TypicalDeviation>0.0041670139178264856</TypicalDeviation>
+     <StepWidth>0.0083340278356529712</StepWidth>
+     <PositionUnit>%</PositionUnit>
+     <SupportedUnits>%|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>1</Minimum>
+       <Maximum>12000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="MTBLSM880ZoomSRMag" Name="Zoom Mag" UniqueName="LSM880.SR.DeviceZoomSRMag" Model="" IsAvailable="true" IsBroken="false" IsBrokenReason="" Motorization="Motorized" IsEmitter="false" IsDetector="false" FirmwareDate="01/25/2022" FirmwareName="MotorControl_Step2x" FirmwareVersion="02.917" SerialNumber="22-04_147434_0053">
+     <MinPosition>67.971158082094632</MinPosition>
+     <MaxPosition>1144.0802143188055</MaxPosition>
+     <MaxDeviation>0.037758212499533712</MaxDeviation>
+     <TypicalDeviation>0.037758212499533712</TypicalDeviation>
+     <StepWidth>0.075516424999067425</StepWidth>
+     <PositionUnit>mm</PositionUnit>
+     <SupportedUnits>%|mm|Steps|</SupportedUnits>
+     <PositionRanges>
+      <Range Unit="%">
+       <Minimum>0</Minimum>
+       <Maximum>100</Maximum>
+      </Range>
+      <Range Unit="mm">
+       <Minimum>67.971158082094632</Minimum>
+       <Maximum>1144.0802143188055</Maximum>
+      </Range>
+      <Range Unit="Steps">
+       <Minimum>750</Minimum>
+       <Maximum>15000</Maximum>
+      </Range>
+     </PositionRanges>
+     <MinMoveSpeed>1</MinMoveSpeed>
+     <MaxMoveSpeed>1</MaxMoveSpeed>
+     <SpeedUnit/>
+    </Device>
+    <Device Id="FcsRealTimeSystem" Name="FcsRealTimeSystem" UniqueName="FcsRealTimeSystem" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+    <Device Id="LaserLifetimeSavingComponent" Name="LaserLifetimeSavingComponent" UniqueName="LaserLifetimeSavingComponent" Model="" IsAvailable="false" IsBroken="false" IsBrokenReason="" Motorization="None" IsEmitter="false" IsDetector="false" FirmwareDate="" FirmwareName="" FirmwareVersion="" SerialNumber=""/>
+   </Configuration>
+  </HardwareSetting>
+  <CustomAttributes/>
+  <Information>
+   <User Id="0"/>
+   <Application>
+    <Name>ZEN (blue edition)</Name>
+    <Version>3.6.095.09000</Version>
+    <BuildId>3.14.23124.83</BuildId>
+   </Application>
+   <Document>
+    <CreationDate>2024-09-23T16:48:19.3804223+02:00</CreationDate>
+    <UserName>zeiss</UserName>
+   </Document>
+   <Image>
+    <SizeX>1908</SizeX>
+    <SizeY>1908</SizeY>
+    <SizeZ>1</SizeZ>
+    <SizeT>1</SizeT>
+    <SizeH>1</SizeH>
+    <OriginalCompressionMethod>Uncompressed</OriginalCompressionMethod>
+    <OriginalEncodingQuality>100</OriginalEncodingQuality>
+    <AcquisitionDateAndTime>2024-09-23T14:47:13.3177177Z</AcquisitionDateAndTime>
+    <SizeC>4</SizeC>
+    <ComponentBitCount>8</ComponentBitCount>
+    <PixelType>Gray8</PixelType>
+    <Dimensions>
+     <Channels>
+      <Channel Id="Channel:0" Name="AF555-T5">
+       <ExcitationWavelength>553</ExcitationWavelength>
+       <EmissionWavelength>568</EmissionWavelength>
+       <DyeId>McNamara-Boswell-0046</DyeId>
+       <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+       <Color>#FFFF7E00</Color>
+       <Fluor>Alexa Fluor 555</Fluor>
+       <Reflector>none</Reflector>
+       <NACondenser>0.55</NACondenser>
+       <IlluminationType>Epifluorescence</IlluminationType>
+       <ContrastMethod>Fluorescence</ContrastMethod>
+       <PinholeSize>57.279820667137</PinholeSize>
+       <PinholeSizeAiry>1.0000000000000082</PinholeSizeAiry>
+       <PixelType>Gray8</PixelType>
+       <ComponentBitCount>8</ComponentBitCount>
+       <AcquisitionMode>LaserScanningConfocalMicroscopy</AcquisitionMode>
+       <DetectionWavelength>
+        <Ranges>551.841189287173-640.415546415441</Ranges>
+       </DetectionWavelength>
+       <DetectorSettings>
+        <HasFocusRoi>false</HasFocusRoi>
+        <DigitalGain>1</DigitalGain>
+        <Offset>0</Offset>
+        <DetectorMode>Integration</DetectorMode>
+        <Voltage>650</Voltage>
+        <PhotonConversionFactor>803.62002809607247</PhotonConversionFactor>
+        <Detector Id="Detector: Spectral"/>
+       </DetectorSettings>
+       <LightSourcesSettings>
+        <LightSourceSettings>
+         <Attenuation>0.998</Attenuation>
+         <Transmission>0.0020000000000000018</Transmission>
+         <Wavelength>561</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine561"/>
+        </LightSourceSettings>
+       </LightSourcesSettings>
+       <LaserScanInfo>
+        <Averaging>2</Averaging>
+        <AveragingMode>Line</AveragingMode>
+        <AveragingMethod>Mean</AveragingMethod>
+        <FrameTime>18.773194966517458</FrameTime>
+        <PixelTime>1.1000895255147716E-06</PixelTime>
+        <ScanSpeed>6</ScanSpeed>
+        <SampleOffsetX>0</SampleOffsetX>
+        <SampleOffsetY>0</SampleOffsetY>
+        <SampleRotation>0</SampleRotation>
+        <ZoomX>1</ZoomX>
+        <ZoomY>1</ZoomY>
+        <ScanDirection>Unidirectional</ScanDirection>
+        <LaserBlanking>true</LaserBlanking>
+        <LineStep>1</LineStep>
+        <ScanningMode>Frame</ScanningMode>
+        <MainBeamSplitterVis>Beamsplitter.2412-349</MainBeamSplitterVis>
+        <MainBeamSplitterInVis>Beamsplitter.1520-117</MainBeamSplitterInVis>
+        <SecondaryBeamSplitter>SecondaryBeamsplitter.453001-4023-000</SecondaryBeamSplitter>
+       </LaserScanInfo>
+      </Channel>
+      <Channel Id="Channel:1" Name="AF488-T6">
+       <ExcitationWavelength>493</ExcitationWavelength>
+       <EmissionWavelength>517</EmissionWavelength>
+       <DyeId>McNamara-Boswell-0038</DyeId>
+       <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+       <Color>#FF00FF33</Color>
+       <Fluor>Alexa Fluor 488</Fluor>
+       <Reflector>none</Reflector>
+       <NACondenser>0.55</NACondenser>
+       <IlluminationType>Epifluorescence</IlluminationType>
+       <ContrastMethod>Fluorescence</ContrastMethod>
+       <PinholeSize>49.664133772725</PinholeSize>
+       <PinholeSizeAiry>1.0000000000000098</PinholeSizeAiry>
+       <PixelType>Gray8</PixelType>
+       <ComponentBitCount>8</ComponentBitCount>
+       <AcquisitionMode>LaserScanningConfocalMicroscopy</AcquisitionMode>
+       <DetectionWavelength>
+        <Ranges>498.696575010212-542.983753574346</Ranges>
+       </DetectionWavelength>
+       <DetectorSettings>
+        <HasFocusRoi>false</HasFocusRoi>
+        <DigitalGain>1</DigitalGain>
+        <Offset>0</Offset>
+        <DetectorMode>Integration</DetectorMode>
+        <Voltage>750</Voltage>
+        <PhotonConversionFactor>223.55986192171395</PhotonConversionFactor>
+        <Detector Id="Detector: Spectral"/>
+       </DetectorSettings>
+       <LightSourcesSettings>
+        <LightSourceSettings>
+         <Attenuation>0.995</Attenuation>
+         <Transmission>0.0050000000000000044</Transmission>
+         <Wavelength>488</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine488"/>
+        </LightSourceSettings>
+       </LightSourcesSettings>
+       <LaserScanInfo>
+        <Averaging>2</Averaging>
+        <AveragingMode>Line</AveragingMode>
+        <AveragingMethod>Mean</AveragingMethod>
+        <FrameTime>18.773194966517458</FrameTime>
+        <PixelTime>1.1000895255147716E-06</PixelTime>
+        <ScanSpeed>6</ScanSpeed>
+        <SampleOffsetX>0</SampleOffsetX>
+        <SampleOffsetY>0</SampleOffsetY>
+        <SampleRotation>0</SampleRotation>
+        <ZoomX>1</ZoomX>
+        <ZoomY>1</ZoomY>
+        <ScanDirection>Unidirectional</ScanDirection>
+        <LaserBlanking>true</LaserBlanking>
+        <LineStep>1</LineStep>
+        <ScanningMode>Frame</ScanningMode>
+        <MainBeamSplitterVis>Beamsplitter.2412-349</MainBeamSplitterVis>
+        <MainBeamSplitterInVis>Beamsplitter.1520-117</MainBeamSplitterInVis>
+        <SecondaryBeamSplitter>SecondaryBeamsplitter.453001-4023-000</SecondaryBeamSplitter>
+       </LaserScanInfo>
+      </Channel>
+      <Channel Id="Channel:2" Name="DAPI-T7">
+       <ExcitationWavelength>353</ExcitationWavelength>
+       <EmissionWavelength>465</EmissionWavelength>
+       <DyeId>McNamara-Boswell-0434</DyeId>
+       <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+       <Color>#FF00A1FF</Color>
+       <Fluor>DAPI</Fluor>
+       <Reflector>none</Reflector>
+       <NACondenser>0.55</NACondenser>
+       <IlluminationType>Epifluorescence</IlluminationType>
+       <ContrastMethod>Fluorescence</ContrastMethod>
+       <PinholeSize>43.282053750585177</PinholeSize>
+       <PinholeSizeAiry>1.0000000000000002</PinholeSizeAiry>
+       <PixelType>Gray8</PixelType>
+       <ComponentBitCount>8</ComponentBitCount>
+       <AcquisitionMode>LaserScanningConfocalMicroscopy</AcquisitionMode>
+       <DetectionWavelength>
+        <Ranges>407.5-500.319396972656</Ranges>
+       </DetectionWavelength>
+       <DetectorSettings>
+        <HasFocusRoi>false</HasFocusRoi>
+        <DigitalGain>1</DigitalGain>
+        <Offset>0</Offset>
+        <DetectorMode>Integration</DetectorMode>
+        <Voltage>650</Voltage>
+        <PhotonConversionFactor>240.90306538234665</PhotonConversionFactor>
+        <Detector Id="Detector: MA-Pmt1"/>
+       </DetectorSettings>
+       <LightSourcesSettings>
+        <LightSourceSettings>
+         <Attenuation>0.998</Attenuation>
+         <Transmission>0.0020000000000000018</Transmission>
+         <Wavelength>405</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine405"/>
+        </LightSourceSettings>
+        <LightSourceSettings>
+         <Attenuation>0.98</Attenuation>
+         <Transmission>0.020000000000000018</Transmission>
+         <Wavelength>639</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine639"/>
+        </LightSourceSettings>
+       </LightSourcesSettings>
+       <LaserScanInfo>
+        <Averaging>2</Averaging>
+        <AveragingMode>Line</AveragingMode>
+        <AveragingMethod>Mean</AveragingMethod>
+        <FrameTime>18.773194966517458</FrameTime>
+        <PixelTime>1.1000895255147716E-06</PixelTime>
+        <ScanSpeed>6</ScanSpeed>
+        <SampleOffsetX>0</SampleOffsetX>
+        <SampleOffsetY>0</SampleOffsetY>
+        <SampleRotation>0</SampleRotation>
+        <ZoomX>1</ZoomX>
+        <ZoomY>1</ZoomY>
+        <ScanDirection>Unidirectional</ScanDirection>
+        <LaserBlanking>true</LaserBlanking>
+        <LineStep>1</LineStep>
+        <ScanningMode>Frame</ScanningMode>
+        <MainBeamSplitterVis>Beamsplitter.2412-349</MainBeamSplitterVis>
+        <MainBeamSplitterInVis>Beamsplitter.1520-117</MainBeamSplitterInVis>
+        <SecondaryBeamSplitter>SecondaryBeamsplitter.453001-4023-000</SecondaryBeamSplitter>
+       </LaserScanInfo>
+      </Channel>
+      <Channel Id="Channel:3" Name="AF647-T7">
+       <ExcitationWavelength>653</ExcitationWavelength>
+       <EmissionWavelength>668</EmissionWavelength>
+       <DyeId>McNamara-Boswell-0057</DyeId>
+       <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+       <Color>#FFFF0014</Color>
+       <Fluor>Alexa Fluor 647</Fluor>
+       <Reflector>none</Reflector>
+       <NACondenser>0.55</NACondenser>
+       <IlluminationType>Epifluorescence</IlluminationType>
+       <ContrastMethod>Fluorescence</ContrastMethod>
+       <PinholeSize>43.282053750585177</PinholeSize>
+       <PinholeSizeAiry>1.0000000000000002</PinholeSizeAiry>
+       <PixelType>Gray8</PixelType>
+       <ComponentBitCount>8</ComponentBitCount>
+       <AcquisitionMode>LaserScanningConfocalMicroscopy</AcquisitionMode>
+       <DetectionWavelength>
+        <Ranges>641.5-757.972050915026</Ranges>
+       </DetectionWavelength>
+       <DetectorSettings>
+        <HasFocusRoi>false</HasFocusRoi>
+        <DigitalGain>1</DigitalGain>
+        <Offset>0</Offset>
+        <DetectorMode>Integration</DetectorMode>
+        <Voltage>650</Voltage>
+        <PhotonConversionFactor>418.86240205498245</PhotonConversionFactor>
+        <Detector Id="Detector: MA-Pmt2"/>
+       </DetectorSettings>
+       <LightSourcesSettings>
+        <LightSourceSettings>
+         <Attenuation>0.998</Attenuation>
+         <Transmission>0.0020000000000000018</Transmission>
+         <Wavelength>405</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine405"/>
+        </LightSourceSettings>
+        <LightSourceSettings>
+         <Attenuation>0.98</Attenuation>
+         <Transmission>0.020000000000000018</Transmission>
+         <Wavelength>639</Wavelength>
+         <IsNlo>false</IsNlo>
+         <Polarization>
+          <StokesParameter1>1</StokesParameter1>
+          <StokesParameter2>-1</StokesParameter2>
+          <StokesParameter3>0</StokesParameter3>
+          <StokesParameter4>0</StokesParameter4>
+         </Polarization>
+         <LightSource Id="MTBLKM980LaserLine639"/>
+        </LightSourceSettings>
+       </LightSourcesSettings>
+       <LaserScanInfo>
+        <Averaging>2</Averaging>
+        <AveragingMode>Line</AveragingMode>
+        <AveragingMethod>Mean</AveragingMethod>
+        <FrameTime>18.773194966517458</FrameTime>
+        <PixelTime>1.1000895255147716E-06</PixelTime>
+        <ScanSpeed>6</ScanSpeed>
+        <SampleOffsetX>0</SampleOffsetX>
+        <SampleOffsetY>0</SampleOffsetY>
+        <SampleRotation>0</SampleRotation>
+        <ZoomX>1</ZoomX>
+        <ZoomY>1</ZoomY>
+        <ScanDirection>Unidirectional</ScanDirection>
+        <LaserBlanking>true</LaserBlanking>
+        <LineStep>1</LineStep>
+        <ScanningMode>Frame</ScanningMode>
+        <MainBeamSplitterVis>Beamsplitter.2412-349</MainBeamSplitterVis>
+        <MainBeamSplitterInVis>Beamsplitter.1520-117</MainBeamSplitterInVis>
+        <SecondaryBeamSplitter>SecondaryBeamsplitter.453001-4023-000</SecondaryBeamSplitter>
+       </LaserScanInfo>
+      </Channel>
+     </Channels>
+     <Tracks>
+      <Track Id="Track:5">
+       <ChannelRefs>
+        <ChannelRef Id="Channel:0"/>
+       </ChannelRefs>
+      </Track>
+      <Track Id="Track:6">
+       <ChannelRefs>
+        <ChannelRef Id="Channel:1"/>
+       </ChannelRefs>
+      </Track>
+      <Track Id="Track:7">
+       <ChannelRefs>
+        <ChannelRef Id="Channel:2"/>
+        <ChannelRef Id="Channel:3"/>
+       </ChannelRefs>
+      </Track>
+     </Tracks>
+     <X>
+      <AxisOrientation>-1</AxisOrientation>
+     </X>
+     <Y>
+      <AxisOrientation>-1</AxisOrientation>
+     </Y>
+     <T>
+      <StartTime>2024-09-23T14:47:13.3177177Z</StartTime>
+      <Positions>
+       <BinaryList>
+        <AttachmentName>TimeStamps</AttachmentName>
+       </BinaryList>
+      </Positions>
+     </T>
+     <Z>
+      <XYZHandedness>Undefined</XYZHandedness>
+      <ZAxisDirection>Undefined</ZAxisDirection>
+      <StartPosition>0</StartPosition>
+     </Z>
+    </Dimensions>
+    <ObjectiveSettings>
+     <RefractiveIndex>1.518</RefractiveIndex>
+     <Medium>Oil</Medium>
+     <ObjectiveRef Id="Objective:1"/>
+    </ObjectiveSettings>
+    <MicroscopeRef Id="Microscope:1"/>
+    <MicroscopeSettings>
+     <EyepieceSettings>
+      <TotalMagnification>630</TotalMagnification>
+     </EyepieceSettings>
+    </MicroscopeSettings>
+    <TubeLenses>
+     <TubeLensRef Id="TubeLens:1"/>
+    </TubeLenses>
+    <Session SessionId="2483c994-6299-468f-8eb1-e4083af09302" SessionName="LSM - 20240923_162603" SessionCreation="Uncalibrated">
+     <SessionMatrix>1 0 0 0 0 -1 0 0 0 0 1 0 0 0 0 1</SessionMatrix>
+     <HolderCwsId>0</HolderCwsId>
+    </Session>
+   </Image>
+   <Instrument>
+    <Microscopes>
+     <Microscope Id="Microscope:1" Name="Axio Observer.Z1 / 7">
+      <Type>Inverted</Type>
+      <UserDefinedName>2842001059</UserDefinedName>
+      <System>LSM 800</System>
+     </Microscope>
+    </Microscopes>
+    <LightSources>
+     <LightSource Id="MTBLKM980LaserLine561">
+      <Power>13</Power>
+      <LightSourceType>
+       <Laser>
+        <Tuneable>false</Tuneable>
+       </Laser>
+      </LightSourceType>
+     </LightSource>
+     <LightSource Id="MTBLKM980LaserLine488">
+      <Power>13</Power>
+      <LightSourceType>
+       <Laser>
+        <Tuneable>false</Tuneable>
+       </Laser>
+      </LightSourceType>
+     </LightSource>
+     <LightSource Id="MTBLKM980LaserLine405">
+      <Power>15</Power>
+      <LightSourceType>
+       <Laser>
+        <Tuneable>false</Tuneable>
+       </Laser>
+      </LightSourceType>
+     </LightSource>
+     <LightSource Id="MTBLKM980LaserLine639">
+      <Power>10</Power>
+      <LightSourceType>
+       <Laser>
+        <Tuneable>false</Tuneable>
+       </Laser>
+      </LightSourceType>
+     </LightSource>
+    </LightSources>
+    <Detectors>
+     <Detector Id="Detector: Spectral" Name="Spectral">
+      <GammaDefault>1</GammaDefault>
+      <Type>GaAsP-PMT</Type>
+      <Zoom>1,1</Zoom>
+      <Offset>0</Offset>
+      <Manufacturer>
+       <Model/>
+      </Manufacturer>
+     </Detector>
+     <Detector Id="Detector: MA-Pmt1" Name="MA-Pmt1">
+      <GammaDefault>1</GammaDefault>
+      <Type>Multialkali-PMT</Type>
+      <Zoom>1,1</Zoom>
+      <Offset>0</Offset>
+      <Manufacturer>
+       <Model/>
+      </Manufacturer>
+     </Detector>
+     <Detector Id="Detector: MA-Pmt2" Name="MA-Pmt2">
+      <GammaDefault>1</GammaDefault>
+      <Type>Multialkali-PMT</Type>
+      <Zoom>1,1</Zoom>
+      <Offset>0</Offset>
+      <Manufacturer>
+       <Model/>
+      </Manufacturer>
+     </Detector>
+    </Detectors>
+    <Objectives>
+     <Objective Id="Objective:1" Name="Plan-Apochromat 63x/1.40 Oil DIC M27">
+      <LensNA>1.4</LensNA>
+      <NominalMagnification>63</NominalMagnification>
+      <WorkingDistance>193</WorkingDistance>
+      <PupilGeometry>Circular</PupilGeometry>
+      <ImmersionRefractiveIndex>1.518</ImmersionRefractiveIndex>
+      <Immersion>Oil</Immersion>
+      <Manufacturer>
+       <Model>Plan-Apochromat 63x/1.40 Oil DIC M27</Model>
+      </Manufacturer>
+     </Objective>
+    </Objectives>
+    <TubeLenses>
+     <TubeLens Id="TubeLens:1" Name="Tubelens LSM"/>
+    </TubeLenses>
+    <Dichroics>
+     <Dichroic Id="Beamsplitter.2412-349" Name="MBS 488/561/639"/>
+     <Dichroic Id="Beamsplitter.1520-117" Name="MBS -405"/>
+     <Dichroic Id="SecondaryBeamsplitter.453001-4023-000" Name="Mirror"/>
+    </Dichroics>
+   </Instrument>
+   <Processing>
+    <LSM>
+     <SamplingFactor>0.99992754528419</SamplingFactor>
+    </LSM>
+   </Processing>
+   <TimelineTracks>
+    <TimelineTrack Name="IncubationRecording Track" Id="Track:1">
+     <TimelineElements>
+      <TimelineElement Id="1">
+       <Time>2024-09-23T14:47:13.3550534Z</Time>
+       <Duration>0.0000</Duration>
+       <EventInformation>
+        <IncubationRecording>
+         <Components>
+          <MTBIncubationTemperatureChannel1 Name="H Insert P">
+           <TargetValue>37</TargetValue>
+           <Value>21.7</Value>
+           <IsEnabled>false</IsEnabled>
+          </MTBIncubationTemperatureChannel1>
+          <MTBIncubationTemperatureChannel2 Name="None">
+           <TargetValue>37</TargetValue>
+           <Value>-0.1</Value>
+           <IsEnabled>false</IsEnabled>
+          </MTBIncubationTemperatureChannel2>
+          <MTBIncubationTemperatureChannel3 Name="H Unit XL">
+           <TargetValue>27</TargetValue>
+           <Value>27.1</Value>
+           <IsEnabled>true</IsEnabled>
+          </MTBIncubationTemperatureChannel3>
+          <MTBIncubationTemperatureChannel4 Name="H Dev Humid">
+           <TargetValue>37</TargetValue>
+           <Value>21.3</Value>
+           <IsEnabled>false</IsEnabled>
+          </MTBIncubationTemperatureChannel4>
+          <MTBIncubationCalibrationSensor Name="Control Sensor T">
+           <Value>-0.1</Value>
+          </MTBIncubationCalibrationSensor>
+          <MTBIncubationCO2Channel Name="CO2 Small V">
+           <TargetValue>5</TargetValue>
+           <Value>-0.1</Value>
+           <IsEnabled>false</IsEnabled>
+          </MTBIncubationCO2Channel>
+          <MTBTemperatureSensor1/>
+          <MTBTemperatureSensor2/>
+          <MTBTemperatureSensor3/>
+         </Components>
+        </IncubationRecording>
+       </EventInformation>
+       <Bounds/>
+       <IsEnabledForAnnotations>true</IsEnabledForAnnotations>
+      </TimelineElement>
+      <TimelineElement Id="2">
+       <Time>2024-09-23T14:47:38.360007Z</Time>
+       <Duration>0.0000</Duration>
+       <EventInformation>
+        <IncubationRecording>
+         <Components>
+          <MTBIncubationTemperatureChannel1 Name="H Insert P">
+           <Value>21.8</Value>
+          </MTBIncubationTemperatureChannel1>
+          <MTBTemperatureSensor1/>
+          <MTBTemperatureSensor2/>
+          <MTBTemperatureSensor3/>
+         </Components>
+        </IncubationRecording>
+       </EventInformation>
+       <Bounds StartB="0"/>
+       <IsEnabledForAnnotations>true</IsEnabledForAnnotations>
+      </TimelineElement>
+     </TimelineElements>
+    </TimelineTrack>
+   </TimelineTracks>
+  </Information>
+  <Scaling>
+   <Metadata/>
+   <AutoScaling>
+    <Type>Measured</Type>
+    <Objective>Objective.420782-9900-799</Objective>
+    <Optovar>Aquila.Tubelens LSM</Optovar>
+    <Reflector>Reflector.none</Reflector>
+    <ObjectiveName>Plan-Apochromat 63x/1.40 Oil DIC M27</ObjectiveName>
+    <OptovarMagnification>1</OptovarMagnification>
+    <ReflectorMagnification>1</ReflectorMagnification>
+    <CameraName>LSM 980</CameraName>
+    <CameraPixelDistance>4.44722222222222,4.44722222222222</CameraPixelDistance>
+   </AutoScaling>
+   <Items>
+    <Distance Id="X">
+     <Value>7.059082892416223E-08</Value>
+     <DefaultUnitFormat>µm</DefaultUnitFormat>
+    </Distance>
+    <Distance Id="Y">
+     <Value>7.059082892416223E-08</Value>
+     <DefaultUnitFormat>µm</DefaultUnitFormat>
+    </Distance>
+   </Items>
+  </Scaling>
+  <DisplaySetting>
+   <Channels>
+    <Channel Id="Channel:0" Name="AF555-T5">
+     <Low>0.0057042229287431884</Low>
+     <High>0.4034563849976453</High>
+     <BitCountRange>8</BitCountRange>
+     <PixelType>Gray8</PixelType>
+     <DyeName>Alexa Fluor 555</DyeName>
+     <IlluminationType>Fluorescence</IlluminationType>
+     <DyeMaxEmission>568</DyeMaxEmission>
+     <DyeMaxExcitation>553</DyeMaxExcitation>
+     <DyeId>McNamara-Boswell-0046</DyeId>
+     <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+     <Color>#FFFF7E00</Color>
+     <OriginalColor>#FFFF7E00</OriginalColor>
+    </Channel>
+    <Channel Id="Channel:1" Name="AF488-T6">
+     <Low>0.0022038062309553178</Low>
+     <High>0.99776785913915822</High>
+     <BitCountRange>8</BitCountRange>
+     <PixelType>Gray8</PixelType>
+     <DyeName>Alexa Fluor 488</DyeName>
+     <IlluminationType>Fluorescence</IlluminationType>
+     <DyeMaxEmission>517</DyeMaxEmission>
+     <DyeMaxExcitation>493</DyeMaxExcitation>
+     <DyeId>McNamara-Boswell-0038</DyeId>
+     <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+     <Color>#FF00FF33</Color>
+     <OriginalColor>#FF00FF33</OriginalColor>
+    </Channel>
+    <Channel Id="Channel:2" Name="DAPI-T7">
+     <Low>0.00041591687325169053</Low>
+     <High>0.68938770545560613</High>
+     <BitCountRange>8</BitCountRange>
+     <PixelType>Gray8</PixelType>
+     <DyeName>DAPI</DyeName>
+     <IlluminationType>Fluorescence</IlluminationType>
+     <DyeMaxEmission>465</DyeMaxEmission>
+     <DyeMaxExcitation>353</DyeMaxExcitation>
+     <DyeId>McNamara-Boswell-0434</DyeId>
+     <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+     <Color>#FF00A1FF</Color>
+     <OriginalColor>#FF00A1FF</OriginalColor>
+    </Channel>
+    <Channel Id="Channel:3" Name="AF647-T7">
+     <Low>0.00021137367101276624</Low>
+     <High>0.33327422860031336</High>
+     <BitCountRange>8</BitCountRange>
+     <PixelType>Gray8</PixelType>
+     <DyeName>Alexa Fluor 647</DyeName>
+     <IlluminationType>Fluorescence</IlluminationType>
+     <DyeMaxEmission>668</DyeMaxEmission>
+     <DyeMaxExcitation>653</DyeMaxExcitation>
+     <DyeId>McNamara-Boswell-0057</DyeId>
+     <DyeDatabaseId>66071726-cbd4-4c41-b371-0a6eee4ae9c5</DyeDatabaseId>
+     <Color>#FFFF0014</Color>
+     <OriginalColor>#FFFF0014</OriginalColor>
+    </Channel>
+   </Channels>
+   <ToneMapping>
+    <Mode>None</Mode>
+    <EnhanceClipLimit>3</EnhanceClipLimit>
+    <EnhanceRegionSizePercentage>15</EnhanceRegionSizePercentage>
+   </ToneMapping>
+   <ViewerRotations>0</ViewerRotations>
+  </DisplaySetting>
+  <Layers/>
+ </Metadata>
+</ImageDocument>

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -70,3 +70,36 @@ def test_transform(xslt_path: str, czi_xml_filename: str):
 
     # Test read from OME-Types
     from_xml(str(omexml))
+
+
+@pytest.mark.parametrize(
+    "czi_xml_filename, expected_lasers",
+    [
+        (
+            "Confocal_test_4c.czi.xml",
+            [
+                '<ome:Laser ID="LightSource:MTBLKM980LaserLine561"/>',
+                '<ome:Laser ID="LightSource:MTBLKM980LaserLine488"/>',
+                '<ome:Laser ID="LightSource:MTBLKM980LaserLine405"/>',
+                '<ome:Laser ID="LightSource:MTBLKM980LaserLine639"/>',
+            ],
+        )
+    ],
+)
+def test_empty_wavelength_transform(xslt_path: str, czi_xml_filename: str, expected_lasers: list):
+    # Arrange
+    czi_xml_filepath = str(RESOURCES_DIR / czi_xml_filename)
+    template = ET.parse(xslt_path)
+    transformer = ET.XSLT(template)
+    czixml = ET.parse(czi_xml_filepath)
+
+    # Act
+    omexml = transformer(czixml)
+    omexml_str = ET.tostring(omexml, pretty_print=True, encoding="unicode")
+
+    # Assert
+    for laser in expected_lasers:
+        assert laser in omexml_str, f"Expected laser {laser} not found in transformed XML"
+
+    # Test that the resulting XML can be read by OME-Types
+    from_xml(omexml_str)

--- a/xslt/Instrument.xsl
+++ b/xslt/Instrument.xsl
@@ -95,17 +95,22 @@ ome/ome.xsd: 979 # # This means that for more details on how this section of the
     <xsl:template match="LightSources">
         <xsl:for-each select="LightSource">
             <xsl:choose>
-                <xsl:when test="LightSourceType/Laser">
-                    <xsl:element name="ome:Laser">
-                        <xsl:attribute name="ID">
-                            <xsl:value-of select="@Id"/>
-                        </xsl:attribute>
+            <xsl:when test="LightSourceType/Laser">
+                <xsl:element name="ome:Laser">
+                    <xsl:attribute name="ID">
+                        <xsl:text>LightSource:</xsl:text>
+                        <xsl:value-of select="@Id"/>
+                    </xsl:attribute>
+
+                    <!-- Add Wavelength only if it's not empty -->
+                    <xsl:if test="string(LightSourceType/Laser/Wavelength) != ''">
                         <xsl:attribute name="Wavelength">
                             <xsl:value-of select="LightSourceType/Laser/Wavelength"/>
                         </xsl:attribute>
-                    </xsl:element>
-                </xsl:when>
-                <xsl:otherwise>
+                    </xsl:if>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
                     <xsl:element name="ome:Filament">
                         <xsl:attribute name="ID">
                             <xsl:value-of select="@Id"/>

--- a/xslt/Instrument.xsl
+++ b/xslt/Instrument.xsl
@@ -95,22 +95,21 @@ ome/ome.xsd: 979 # # This means that for more details on how this section of the
     <xsl:template match="LightSources">
         <xsl:for-each select="LightSource">
             <xsl:choose>
-            <xsl:when test="LightSourceType/Laser">
-                <xsl:element name="ome:Laser">
-                    <xsl:attribute name="ID">
-                        <xsl:text>LightSource:</xsl:text>
-                        <xsl:value-of select="@Id"/>
-                    </xsl:attribute>
-
-                    <!-- Add Wavelength only if it's not empty -->
-                    <xsl:if test="string(LightSourceType/Laser/Wavelength) != ''">
-                        <xsl:attribute name="Wavelength">
-                            <xsl:value-of select="LightSourceType/Laser/Wavelength"/>
+                <xsl:when test="LightSourceType/Laser">
+                    <xsl:element name="ome:Laser">
+                        <xsl:attribute name="ID">
+                            <xsl:text>LightSource:</xsl:text>
+                            <xsl:value-of select="@Id"/>
                         </xsl:attribute>
-                    </xsl:if>
-                </xsl:element>
-            </xsl:when>
-            <xsl:otherwise>
+                        <!-- Add Wavelength only if it's not empty -->
+                        <xsl:if test="string(LightSourceType/Laser/Wavelength) != ''">
+                            <xsl:attribute name="Wavelength">
+                                <xsl:value-of select="LightSourceType/Laser/Wavelength"/>
+                            </xsl:attribute>
+                        </xsl:if>
+                    </xsl:element>
+                </xsl:when>
+                <xsl:otherwise>
                     <xsl:element name="ome:Filament">
                         <xsl:attribute name="ID">
                             <xsl:value-of select="@Id"/>


### PR DESCRIPTION
### Description 

This PR is a response to https://github.com/bioio-devs/bioio-czi/issues/19#issuecomment-2540320107. Our current transform from the czi schema to the OME schema does not account for an empty wavelength leading to parsing issues. Additionally, light sources need to be prefaced with "LightSource:" 
